### PR TITLE
Use `rustfmt` for formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "git.inputValidationLength": 72,
   "[rust]": {
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "jinxdash.prettier-rust"
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
   "rust-analyzer.check.command": "clippy"
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    tauri_build::build()
+  tauri_build::build()
 }

--- a/src-tauri/rustfmt.toml
+++ b/src-tauri/rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 2

--- a/src-tauri/src/audio/commands.rs
+++ b/src-tauri/src/audio/commands.rs
@@ -1,24 +1,27 @@
 use std::sync::Mutex;
 
+use super::{models::AudioStream, service::create_system_audio_stream};
+use crate::AppState;
 use cpal::traits::StreamTrait;
 use serde::Serialize;
-use tauri::{ ipc::Channel, State };
-use crate::AppState;
-use super::{ models::AudioStream, service::create_system_audio_stream };
+use tauri::{ipc::Channel, State};
 
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase", rename_all_fields = "camelCase", tag = "event", content = "data")]
+#[serde(
+  rename_all = "camelCase",
+  rename_all_fields = "camelCase",
+  tag = "event",
+  content = "data"
+)]
 pub enum AudioStreamChannel {
-  Signal {
-    decibels: f32,
-  },
+  Signal { decibels: f32 },
 }
 
 #[tauri::command]
 pub fn start_audio_listener(
   state: State<'_, Mutex<AppState>>,
   stream_name: AudioStream,
-  on_event: Channel<AudioStreamChannel>
+  on_event: Channel<AudioStreamChannel>,
 ) {
   let mut state = state.lock().unwrap();
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,3 +1,3 @@
 pub mod commands;
-pub mod service;
 pub mod models;
+pub mod service;

--- a/src-tauri/src/audio/models.rs
+++ b/src-tauri/src/audio/models.rs
@@ -1,4 +1,4 @@
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Display, PartialEq, Eq, Hash)]

--- a/src-tauri/src/audio/service.rs
+++ b/src-tauri/src/audio/service.rs
@@ -1,17 +1,17 @@
 use std::collections::VecDeque;
 
-use cpal::{ traits::{ DeviceTrait, HostTrait }, Stream };
-use tauri::{ ipc::Channel, Emitter };
+use cpal::{
+  traits::{DeviceTrait, HostTrait},
+  Stream,
+};
+use tauri::{ipc::Channel, Emitter};
 
 use crate::APP_HANDLE;
 
 use super::commands::AudioStreamChannel;
 
 fn buffer_to_decibels(samples: &[f32]) -> f32 {
-  let sum_squares: f32 = samples
-    .iter()
-    .map(|&s| s * s)
-    .sum();
+  let sum_squares: f32 = samples.iter().map(|&s| s * s).sum();
 
   let mean_square: f32 = sum_squares / (samples.len() as f32);
   let rms = mean_square.sqrt();
@@ -27,8 +27,12 @@ pub fn create_system_audio_stream(channel: Channel<AudioStreamChannel>) -> Strea
   const BUFFER_SIZE: usize = 1024;
 
   let host = cpal::host_from_id(cpal::HostId::ScreenCaptureKit).unwrap();
-  let device = host.default_input_device().expect("No default device found");
-  let config = device.default_input_config().expect("Unsupported input config");
+  let device = host
+    .default_input_device()
+    .expect("No default device found");
+  let config = device
+    .default_input_config()
+    .expect("Unsupported input config");
 
   let mut buffer = VecDeque::with_capacity(BUFFER_SIZE);
   let mut previous_smoothed = -100.0;
@@ -48,18 +52,29 @@ pub fn create_system_audio_stream(channel: Channel<AudioStreamChannel>) -> Strea
         if buffer.len() == BUFFER_SIZE {
           let current_raw = buffer_to_decibels(buffer.make_contiguous());
           let delta = (current_raw - previous_raw).abs();
-          let alpha = if delta > 5.0 { 0.2 } else if delta < 2.0 { 0.01 } else { 0.1 };
+          let alpha = if delta > 5.0 {
+            0.2
+          } else if delta < 2.0 {
+            0.01
+          } else {
+            0.1
+          };
           let smoothed = adaptive_ema(current_raw, previous_smoothed, alpha);
 
-          channel.send(AudioStreamChannel::Signal { decibels: smoothed }).unwrap();
+          channel
+            .send(AudioStreamChannel::Signal { decibels: smoothed })
+            .unwrap();
           previous_raw = current_raw;
           previous_smoothed = smoothed;
         }
       },
       move |_err| {
-        let _ = APP_HANDLE.get().unwrap().emit("system_audio_stream_error", ());
+        let _ = APP_HANDLE
+          .get()
+          .unwrap()
+          .emit("system_audio_stream_error", ());
       },
-      None
+      None,
     )
     .expect("Error creating stream")
 }

--- a/src-tauri/src/global_inputs/service.rs
+++ b/src-tauri/src/global_inputs/service.rs
@@ -1,4 +1,4 @@
-use rdev::{ Button, Event, EventType };
+use rdev::{Button, Event, EventType};
 use tauri::Emitter;
 
 use crate::APP_HANDLE;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,37 +1,37 @@
+mod audio;
 mod global_inputs;
 #[cfg(target_os = "macos")]
 mod permissions;
+mod store;
 mod system_tray;
 mod windows;
-mod store;
-mod audio;
 
-use std::{ collections::HashMap, sync::{ Arc, Mutex, OnceLock } };
+use std::{
+  collections::HashMap,
+  sync::{Arc, Mutex, OnceLock},
+};
 
 use audio::{
-  commands::{ start_audio_listener, stop_all_audio_listeners, stop_audio_listener },
+  commands::{start_audio_listener, stop_all_audio_listeners, stop_audio_listener},
   models::AudioStream,
 };
 use cpal::Stream;
 use permissions::{
-  commands::{ check_permissions, open_system_settings, request_permission },
-  service::{ ensure_permissions, monitor_permissions },
+  commands::{check_permissions, open_system_settings, request_permission},
+  service::{ensure_permissions, monitor_permissions},
 };
 use rdev::listen;
-use serde_json::{ json, Value };
-use store::constants::{ FIRST_RUN, NATIVE_REQUESTABLE_PERMISSIONS, STORE_NAME };
+use serde_json::{json, Value};
+use store::constants::{FIRST_RUN, NATIVE_REQUESTABLE_PERMISSIONS, STORE_NAME};
 use system_tray::service::create_system_tray;
-use tauri::{ App, AppHandle, Manager, Wry };
-use tauri_plugin_store::{ Store, StoreExt };
+use tauri::{App, AppHandle, Manager, Wry};
+use tauri_plugin_store::{Store, StoreExt};
 use windows::{
   commands::{
-    hide_start_recording_dock,
-    init_standalone_listbox,
-    quit_app,
-    show_standalone_listbox,
+    hide_start_recording_dock, init_standalone_listbox, quit_app, show_standalone_listbox,
     show_start_recording_dock,
   },
-  service::{ init_start_recording_panel, open_permissions },
+  service::{init_start_recording_panel, open_permissions},
 };
 
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
@@ -56,7 +56,7 @@ async fn setup_store(app: &App) -> Arc<Store<Wry>> {
         "screen": true,
         "microphone": true,
         "camera": true
-      })
+      }),
     );
   }
 
@@ -67,27 +67,22 @@ async fn setup_store(app: &App) -> Arc<Store<Wry>> {
 pub fn run() {
   let context = tauri::generate_context!();
 
-  let app = tauri::Builder
-    ::default()
-    .invoke_handler(
-      tauri::generate_handler![
-        check_permissions,
-        request_permission,
-        open_system_settings,
-        quit_app,
-        init_standalone_listbox,
-        show_standalone_listbox,
-        hide_start_recording_dock,
-        start_audio_listener,
-        stop_audio_listener,
-        stop_all_audio_listeners
-      ]
-    )
-    .manage(
-      Mutex::new(AppState {
-        audio_streams: HashMap::new(),
-      })
-    )
+  let app = tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![
+      check_permissions,
+      request_permission,
+      open_system_settings,
+      quit_app,
+      init_standalone_listbox,
+      show_standalone_listbox,
+      hide_start_recording_dock,
+      start_audio_listener,
+      stop_audio_listener,
+      stop_all_audio_listeners
+    ])
+    .manage(Mutex::new(AppState {
+      audio_streams: HashMap::new(),
+    }))
     .plugin(tauri_plugin_opener::init())
     .plugin(tauri_plugin_macos_permissions::init())
     .plugin(tauri_nspanel::init())

--- a/src-tauri/src/permissions/commands.rs
+++ b/src-tauri/src/permissions/commands.rs
@@ -1,10 +1,13 @@
-use tauri::{ AppHandle };
+use tauri::AppHandle;
 use tauri_plugin_shell::ShellExt;
 use tauri_plugin_store::StoreExt;
 
 use crate::STORE_NAME;
 
-use super::{ models::{ CheckPermissionsResponse, PermissionType }, service };
+use super::{
+  models::{CheckPermissionsResponse, PermissionType},
+  service,
+};
 
 /// Check status of permission.
 ///
@@ -18,7 +21,7 @@ pub async fn check_permissions(app_handle: AppHandle) -> CheckPermissionsRespons
 #[tauri::command]
 pub async fn request_permission(
   app_handle: AppHandle,
-  permission: PermissionType
+  permission: PermissionType,
 ) -> Result<(), String> {
   match service::request_permission(app_handle.store(STORE_NAME).unwrap(), permission).await {
     Ok(()) => Ok(()),

--- a/src-tauri/src/permissions/mod.rs
+++ b/src-tauri/src/permissions/mod.rs
@@ -1,3 +1,3 @@
 pub mod commands;
-pub mod service;
 mod models;
+pub mod service;

--- a/src-tauri/src/permissions/models.rs
+++ b/src-tauri/src/permissions/models.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Display, PartialEq, Eq, Hash)]

--- a/src-tauri/src/permissions/service.rs
+++ b/src-tauri/src/permissions/service.rs
@@ -1,25 +1,20 @@
-use std::{ collections::HashMap, sync::Arc, time::Duration };
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use tauri::{ AppHandle, Emitter, Wry };
+use tauri::{AppHandle, Emitter, Wry};
 use tauri_plugin_macos_permissions::{
-  check_accessibility_permission,
-  check_camera_permission,
-  check_microphone_permission,
-  check_screen_recording_permission,
-  request_accessibility_permission,
-  request_camera_permission,
-  request_microphone_permission,
-  request_screen_recording_permission,
+  check_accessibility_permission, check_camera_permission, check_microphone_permission,
+  check_screen_recording_permission, request_accessibility_permission, request_camera_permission,
+  request_microphone_permission, request_screen_recording_permission,
 };
-use tauri_plugin_store::{ Store, StoreExt };
+use tauri_plugin_store::{Store, StoreExt};
 use tokio::time::interval;
 
 use crate::{
   permissions::models::NativeRequestablePermissions,
-  store::constants::{ NATIVE_REQUESTABLE_PERMISSIONS, STORE_NAME },
+  store::constants::{NATIVE_REQUESTABLE_PERMISSIONS, STORE_NAME},
 };
 
-use super::models::{ CheckPermissionsResponse, PermissionStatus, PermissionType };
+use super::models::{CheckPermissionsResponse, PermissionStatus, PermissionType};
 
 /// Verify app has all required permissions.
 pub async fn ensure_permissions() -> bool {
@@ -33,12 +28,15 @@ pub async fn check_permissions(store: Arc<Store<Wry>>) -> CheckPermissionsRespon
     map: &mut HashMap<String, PermissionStatus>,
     permission_name: &str,
     can_request: bool,
-    has_access: bool
+    has_access: bool,
   ) {
-    map.insert(permission_name.to_string(), PermissionStatus {
-      can_request,
-      has_access,
-    });
+    map.insert(
+      permission_name.to_string(),
+      PermissionStatus {
+        can_request,
+        has_access,
+      },
+    );
   }
 
   let (accessibility, screen, microphone, camera) = tokio::join!(
@@ -48,9 +46,8 @@ pub async fn check_permissions(store: Arc<Store<Wry>>) -> CheckPermissionsRespon
     check_camera_permission()
   );
 
-  let native_requestable_permissions: NativeRequestablePermissions = serde_json
-    ::from_value(store.get(NATIVE_REQUESTABLE_PERMISSIONS).unwrap())
-    .unwrap();
+  let native_requestable_permissions: NativeRequestablePermissions =
+    serde_json::from_value(store.get(NATIVE_REQUESTABLE_PERMISSIONS).unwrap()).unwrap();
 
   let mut permissions_map: HashMap<String, PermissionStatus> = HashMap::new();
 
@@ -58,19 +55,29 @@ pub async fn check_permissions(store: Arc<Store<Wry>>) -> CheckPermissionsRespon
     &mut permissions_map,
     "accessibility",
     native_requestable_permissions.accessibility,
-    accessibility
+    accessibility,
   );
 
-  insert_permission(&mut permissions_map, "screen", native_requestable_permissions.screen, screen);
+  insert_permission(
+    &mut permissions_map,
+    "screen",
+    native_requestable_permissions.screen,
+    screen,
+  );
 
   insert_permission(
     &mut permissions_map,
     "microphone",
     native_requestable_permissions.microphone,
-    microphone
+    microphone,
   );
 
-  insert_permission(&mut permissions_map, "camera", native_requestable_permissions.camera, camera);
+  insert_permission(
+    &mut permissions_map,
+    "camera",
+    native_requestable_permissions.camera,
+    camera,
+  );
 
   CheckPermissionsResponse {
     permissions: permissions_map,
@@ -101,7 +108,7 @@ pub async fn monitor_permissions(app_handle: Arc<AppHandle>) -> Result<(), Strin
 
 pub async fn request_permission(
   store: Arc<Store<Wry>>,
-  permission: PermissionType
+  permission: PermissionType,
 ) -> Result<(), String> {
   match permission {
     PermissionType::Accessibility => request_accessibility_permission().await,
@@ -118,7 +125,10 @@ pub async fn request_permission(
 
   native_requestable_permissions.insert(permission.to_string(), serde_json::Value::Bool(false));
 
-  store.set(NATIVE_REQUESTABLE_PERMISSIONS, native_requestable_permissions);
+  store.set(
+    NATIVE_REQUESTABLE_PERMISSIONS,
+    native_requestable_permissions,
+  );
 
   Ok(())
 }

--- a/src-tauri/src/system_tray/service.rs
+++ b/src-tauri/src/system_tray/service.rs
@@ -1,5 +1,5 @@
-use tauri::menu::{ Menu, MenuItem };
-use tauri::tray::{ MouseButton, MouseButtonState, TrayIconEvent };
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
 use tauri::App;
 
 use crate::windows::commands::show_start_recording_dock;
@@ -8,25 +8,22 @@ pub fn create_system_tray(app: &App) -> tauri::Result<()> {
   let quit_i = MenuItem::with_id(app, "quit", "Quit Orbit Cursor", true, None::<&str>)?;
   let menu = Menu::with_items(app, &[&quit_i])?;
   let tray = app.tray_by_id("tray_icon").unwrap();
-  tray.on_menu_event(|app, event| {
-    match event.id.as_ref() {
-      "quit" => {
-        app.exit(0);
-      }
-      _ => {
-        println!("menu item {:?} not handled", event.id);
-      }
+  tray.on_menu_event(|app, event| match event.id.as_ref() {
+    "quit" => {
+      app.exit(0);
+    }
+    _ => {
+      println!("menu item {:?} not handled", event.id);
     }
   });
   tray.set_menu(Some(menu))?;
   tray.set_show_menu_on_left_click(false)?;
   tray.on_tray_icon_event(|tray, event| {
-    if
-      let TrayIconEvent::Click {
-        button: MouseButton::Left,
-        button_state: MouseButtonState::Up,
-        ..
-      } = event
+    if let TrayIconEvent::Click {
+      button: MouseButton::Left,
+      button_state: MouseButtonState::Up,
+      ..
+    } = event
     {
       let app_handle = tray.app_handle();
       show_start_recording_dock(app_handle);

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -1,11 +1,10 @@
 use std::sync::Once;
 
-use tauri::{ AppHandle, Emitter };
+use tauri::{AppHandle, Emitter};
 use tauri_nspanel::ManagerExt;
 
 use super::service::{
-  position_and_size_standalone_listbox_panel,
-  setup_standalone_listbox_listeners,
+  position_and_size_standalone_listbox_panel, setup_standalone_listbox_listeners,
   swizzle_to_standalone_listbox_panel,
 };
 
@@ -33,7 +32,9 @@ pub fn show_standalone_listbox(app_handle: AppHandle, x: f64, y: f64, width: f64
 
 #[tauri::command]
 pub fn show_start_recording_dock(app_handle: &AppHandle) {
-  let panel = app_handle.get_webview_panel("start_recording_dock").unwrap();
+  let panel = app_handle
+    .get_webview_panel("start_recording_dock")
+    .unwrap();
   panel.order_front_regardless();
 
   // Showing/hiding doesn't remount component, instead we emit event to UI
@@ -44,6 +45,8 @@ pub fn show_start_recording_dock(app_handle: &AppHandle) {
 
 #[tauri::command]
 pub fn hide_start_recording_dock(app_handle: AppHandle) {
-  let panel = app_handle.get_webview_panel("start_recording_dock").unwrap();
+  let panel = app_handle
+    .get_webview_panel("start_recording_dock")
+    .unwrap();
   panel.order_out(None);
 }

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -1,22 +1,18 @@
 use std::ffi::CString;
 
 use border::WebviewWindowExt as BorderWebviewWindowExt;
-use cocoa::{ appkit::{ NSMainMenuWindowLevel, NSWindowCollectionBehavior }, base::{ id, nil } };
-use objc::{ class, msg_send, sel, sel_impl };
+use cocoa::{
+  appkit::{NSMainMenuWindowLevel, NSWindowCollectionBehavior},
+  base::{id, nil},
+};
+use objc::{class, msg_send, sel, sel_impl};
 use tauri::{
   utils::config::WindowEffectsConfig,
-  window::{ Effect, EffectState },
-  AppHandle,
-  Emitter,
-  Listener,
-  LogicalSize,
-  Manager,
-  PhysicalPosition,
-  Size,
-  WebviewWindow,
+  window::{Effect, EffectState},
+  AppHandle, Emitter, Listener, LogicalSize, Manager, PhysicalPosition, Size, WebviewWindow,
   WebviewWindowBuilder,
 };
-use tauri_nspanel::{ block::ConcreteBlock, panel_delegate, ManagerExt, WebviewWindowExt };
+use tauri_nspanel::{block::ConcreteBlock, panel_delegate, ManagerExt, WebviewWindowExt};
 
 #[allow(non_upper_case_globals)]
 const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
@@ -31,7 +27,10 @@ pub fn handle_record_dock_positioning(window: &WebviewWindow) -> tauri::Result<(
 
     if label == "start_recording_dock" {
       let x = (monitor_size.width / 2).saturating_sub(window_size.width / 2);
-      let y = monitor_size.height.saturating_sub(window_size.height).saturating_sub(200);
+      let y = monitor_size
+        .height
+        .saturating_sub(window_size.height)
+        .saturating_sub(200);
       window.set_position(PhysicalPosition { x, y })?;
     }
   }
@@ -52,23 +51,23 @@ pub async fn open_permissions(app_handle: &AppHandle) {
   let window = WebviewWindowBuilder::new(
     app_handle,
     "request_permissions",
-    tauri::WebviewUrl::App("/request-permissions".into())
+    tauri::WebviewUrl::App("/request-permissions".into()),
   )
-    .title("Request Permissions")
-    .inner_size(540.0, 432.0)
-    .decorations(false)
-    .resizable(false)
-    .shadow(true)
-    .transparent(true)
-    .closable(false)
-    .effects(WindowEffectsConfig {
-      effects: vec![Effect::UnderWindowBackground],
-      state: Some(EffectState::Active),
-      radius: Some(10.0),
-      color: None,
-    })
-    .build()
-    .unwrap();
+  .title("Request Permissions")
+  .inner_size(540.0, 432.0)
+  .decorations(false)
+  .resizable(false)
+  .shadow(true)
+  .transparent(true)
+  .closable(false)
+  .effects(WindowEffectsConfig {
+    effects: vec![Effect::UnderWindowBackground],
+    state: Some(EffectState::Active),
+    radius: Some(10.0),
+    color: None,
+  })
+  .build()
+  .unwrap();
 
   add_border(&window).ok();
 
@@ -76,7 +75,9 @@ pub async fn open_permissions(app_handle: &AppHandle) {
 }
 
 pub fn init_start_recording_panel(app_handle: &AppHandle) {
-  let window = app_handle.get_webview_window("start_recording_dock").unwrap();
+  let window = app_handle
+    .get_webview_window("start_recording_dock")
+    .unwrap();
   handle_record_dock_positioning(&window).ok();
   add_border(&window).ok();
 
@@ -85,14 +86,16 @@ pub fn init_start_recording_panel(app_handle: &AppHandle) {
   panel.set_level(NSMainMenuWindowLevel + 1);
 
   panel.set_collection_behaviour(
-    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary |
-      NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces |
-      NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
+    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary
+      | NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
+      | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary,
   );
 
   panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
 
-  let window = app_handle.get_webview_window("start_recording_dock").unwrap();
+  let window = app_handle
+    .get_webview_window("start_recording_dock")
+    .unwrap();
   unsafe {
     let ns_window: id = window.ns_window().unwrap() as id;
     // Available enum values: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.9.sdk/System/Library/Frameworks/AppKit.framework/Versions/C/Headers/NSWindow.h?#L131
@@ -112,20 +115,18 @@ pub fn swizzle_to_standalone_listbox_panel(app_handle: &AppHandle) {
 
   let handle = app_handle.clone();
 
-  panel_delegate.set_listener(
-    Box::new(move |delegate_name: String| {
-      if delegate_name.as_str() == "window_did_resign_key" {
-        let _ = handle.emit("standalone_listbox_did_resign_key", ());
-      }
-    })
-  );
+  panel_delegate.set_listener(Box::new(move |delegate_name: String| {
+    if delegate_name.as_str() == "window_did_resign_key" {
+      let _ = handle.emit("standalone_listbox_did_resign_key", ());
+    }
+  }));
 
   panel.set_level(NSMainMenuWindowLevel + 2);
 
   panel.set_collection_behaviour(
-    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary |
-      NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces |
-      NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary
+    NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary
+      | NSWindowCollectionBehavior::NSWindowCollectionBehaviorCanJoinAllSpaces
+      | NSWindowCollectionBehavior::NSWindowCollectionBehaviorStationary,
   );
 
   panel.set_delegate(panel_delegate);
@@ -160,7 +161,7 @@ pub fn setup_standalone_listbox_listeners(app_handle: &AppHandle) {
 
   register_workspace_listener(
     "NSWorkspaceDidActivateApplicationNotification".into(),
-    callback.clone()
+    callback.clone(),
   );
 }
 
@@ -169,11 +170,13 @@ pub fn position_and_size_standalone_listbox_panel(
   x: f64,
   y: f64,
   width: f64,
-  height: f64
+  height: f64,
 ) {
   let window = app_handle.get_webview_window("standalone_listbox").unwrap();
   window.set_position(PhysicalPosition { x, y }).ok();
-  window.set_size(Size::Logical(LogicalSize { width, height })).ok();
+  window
+    .set_size(Size::Logical(LogicalSize { width, height }))
+    .ok();
 }
 
 fn register_workspace_listener(name: String, callback: Box<dyn Fn()>) {
@@ -183,16 +186,14 @@ fn register_workspace_listener(name: String, callback: Box<dyn Fn()>) {
 
   let block = ConcreteBlock::new(move |_notification: id| callback());
 
-  let name: id = unsafe {
-    msg_send![class!(NSString), stringWithCString: CString::new(name).unwrap()]
-  };
+  let name: id =
+    unsafe { msg_send![class!(NSString), stringWithCString: CString::new(name).unwrap()] };
 
   unsafe {
-    let _: () =
-      msg_send![
-          notification_center,
-          addObserverForName: name object: nil queue: nil usingBlock: block
-        ];
+    let _: () = msg_send![
+      notification_center,
+      addObserverForName: name object: nil queue: nil usingBlock: block
+    ];
   }
 }
 


### PR DESCRIPTION
The formatter should take as many decisions away from the developer as possible. Less mental tax. `rustfmt` is the defacto formatter and even does import sorting.