### PR TITLE
Standardize storybook meta to `satisfies`

### DIFF
--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -19,9 +19,8 @@ const colors: React.ComponentProps<typeof Button>["color"][] = [
   "info",
 ];
 
-const meta: Meta<typeof Button> = {
+const meta = {
   argTypes: {
-    ref: { control: { disable: true } },
     size: {
       control: "inline-radio",
       options: sizes,
@@ -38,17 +37,26 @@ const meta: Meta<typeof Button> = {
   },
   component: Button,
   parameters: {
+    controls: {
+      exclude: ["ref", "className"],
+    },
     layout: "centered",
   },
   title: "Button",
-};
+} satisfies Meta<typeof Button>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 /* --------------------------------- Stories -------------------------------- */
 export const Default: Story = {
-  args: { size: "md", variant: "solid" },
+  args: {
+    /* eslint-disable sort-keys */
+    size: "md",
+    variant: "solid",
+    shiny: false,
+    /* eslint-enable sort-keys */
+  },
 };
 
 export const Sizes: Story = {

--- a/src/components/keyboard/keyboard.stories.tsx
+++ b/src/components/keyboard/keyboard.stories.tsx
@@ -14,7 +14,6 @@ const variants: React.ComponentProps<typeof Keyboard>["variant"][] = [
 
 const meta = {
   argTypes: {
-    children: { control: { disable: true } },
     size: {
       control: "inline-radio",
       options: sizes,
@@ -32,6 +31,7 @@ const meta = {
   },
   component: Keyboard,
   parameters: {
+    controls: { exclude: ["children", "ref"] },
     layout: "centered",
   },
   title: "Keyboard",

--- a/src/components/listbox/listbox.stories.tsx
+++ b/src/components/listbox/listbox.stories.tsx
@@ -5,13 +5,20 @@ import ListBoxItem from "../listbox-item/listbox-item";
 import ListBox from "./listbox";
 
 const meta = {
+  argTypes: {
+    selectionMode: {
+      control: "inline-radio",
+      options: ["single", "multiple"],
+      table: { defaultValue: { summary: "solid" } },
+    },
+  },
   args: {
     className: "w-[180px]",
     selectionMode: "single",
   },
   component: ListBox,
   parameters: {
-    controls: { disable: true },
+    controls: { exclude: ["className", "children", "ref"] },
     layout: "centered",
   },
   title: "ListBox",
@@ -49,7 +56,9 @@ export const Compact: Story = {
   },
 };
 
-export const Empty: Story = {};
+export const Empty: Story = {
+  parameters: { controls: { disable: true } },
+};
 
 export const LongValue: Story = {
   args: {
@@ -60,4 +69,5 @@ export const LongValue: Story = {
       </ListBoxItem>
     ),
   },
+  parameters: { controls: { disable: true } },
 };

--- a/src/components/overlay/overlay.stories.tsx
+++ b/src/components/overlay/overlay.stories.tsx
@@ -54,6 +54,7 @@ const meta = {
     },
   ],
   parameters: {
+    controls: { exclude: ["className", "children"] },
     layout: "centered",
   },
   title: "Overlay",

--- a/src/components/select/select.stories.tsx
+++ b/src/components/select/select.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
   },
   component: Select,
   parameters: {
-    controls: { disable: true },
+    controls: { include: ["label"] },
     layout: "centered",
   },
   title: "Select",

--- a/src/components/separator/separator.stories.tsx
+++ b/src/components/separator/separator.stories.tsx
@@ -4,11 +4,15 @@ import Separator from "./separator";
 
 const meta = {
   argTypes: {
-    orientation: {},
+    orientation: {
+      control: "inline-radio",
+      options: ["horizontal", "vertical"],
+      table: { readonly: true },
+    },
   },
   component: Separator,
   parameters: {
-    controls: { disable: true },
+    controls: { exclude: ["className"] },
     layout: "centered",
   },
   title: "Separator",
@@ -19,6 +23,9 @@ type Story = StoryObj<typeof meta>;
 
 /* --------------------------------- Stories -------------------------------- */
 export const Horizontal: Story = {
+  args: {
+    orientation: "vertical",
+  },
   render: () => (
     <div className="text-content-fg text-center">
       Hello
@@ -29,9 +36,12 @@ export const Horizontal: Story = {
 };
 
 /**
- * The container will need a determined height, otherwise use a class like `h-[10px]`.
+ * The container will need a determined height, otherwise add a class like `h-[10px]`.
  */
 export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
   render: () => (
     <div className="text-content-fg text-center flex">
       Hello

--- a/src/components/sparkles/sparkles.stories.tsx
+++ b/src/components/sparkles/sparkles.stories.tsx
@@ -17,10 +17,12 @@ const meta = {
     children: (
       <span className="font-bold text-3xl text-content-fg">sparkles</span>
     ),
+    fillType: "fill-only",
     icon: Sparkle,
   },
   component: Sparkles,
   parameters: {
+    controls: { include: ["fillType"] },
     layout: "centered",
   },
   title: "Sparkles",

--- a/src/components/switch/switch.stories.tsx
+++ b/src/components/switch/switch.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   args: { children: "Label" },
   component: Switch,
   parameters: {
+    controls: { include: ["size"] },
     layout: "centered",
   },
   title: "Switch",

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -36,6 +36,7 @@ const meta = {
   },
   component: Tooltip,
   parameters: {
+    controls: { include: ["withArrow"] },
     layout: "centered",
   },
   title: "Tooltip",

--- a/src/features/recording-controls/components/icon-radio.stories.tsx
+++ b/src/features/recording-controls/components/icon-radio.stories.tsx
@@ -6,27 +6,37 @@ import RadioGroup from "../../../components/radio-group/radio-group";
 
 import IconRadio from "./icon-radio";
 
-const meta: Meta<typeof IconRadio> = {
+const meta = {
+  args: {
+    icon: <Rabbit />,
+    shortcut: <Keyboard size="xs">⌘1</Keyboard>,
+    subtext: "Fast",
+    value: "fast",
+  },
   component: IconRadio,
   parameters: {
-    controls: { disable: true },
+    controls: { exclude: ["icon", "shortcut"] },
     layout: "centered",
   },
   title: "Start Recording/Icon Option",
-};
+} satisfies Meta<typeof IconRadio>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: () => (
+  render: (args) => (
     <RadioGroup aria-label="Speed" orientation="horizontal">
-      <IconRadio
-        icon={<Rabbit />}
-        shortcut={<Keyboard size="xs">⌘1</Keyboard>}
-        subtext="Fast"
-        value="fast"
-      />
+      <IconRadio {...args} />
+    </RadioGroup>
+  ),
+};
+
+export const Multiple: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <RadioGroup aria-label="Speed" orientation="horizontal">
+      <IconRadio {...args} icon={<Rabbit />} subtext="Fast" value="fast" />
       <IconRadio icon={<Snail />} subtext="Slow" value="slow" />
     </RadioGroup>
   ),


### PR DESCRIPTION
Clean up all stories removing unnecessary controls, such as `className` and `ref`, only editable controls remain.