### PR TITLE
Refactor dock focus styles

### DIFF
--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -49,7 +49,7 @@ pub fn show_standalone_listbox(app_handle: AppHandle, x: f64, y: f64, width: f64
 pub fn show_recording_input_options(
   app_handle: AppHandle,
   state: State<'_, Mutex<AppState>>,
-  x: i32,
+  x: f64,
 ) {
   let mut state = state.lock().unwrap();
   state.recording_input_options_opened = true;

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -207,8 +207,8 @@ pub fn swizzle_to_recording_input_options_panel(app_handle: &AppHandle) {
   panel.order_out(None);
 }
 
-pub fn position_recording_input_options_panel(app_handle: &AppHandle, x: i32) {
-  let margin_bottom = 20;
+pub fn position_recording_input_options_panel(app_handle: &AppHandle, x: f64) {
+  let margin_bottom = 20.0;
   let dock = app_handle
     .get_webview_window("start_recording_dock")
     .unwrap();
@@ -218,9 +218,9 @@ pub fn position_recording_input_options_panel(app_handle: &AppHandle, x: i32) {
 
   window
     .set_position(PhysicalPosition {
-      x: x - (window.outer_size().unwrap().width as i32) / 2,
-      y: dock.outer_position().unwrap().y
-        - window.outer_size().unwrap().height as i32
+      x: x - (window.outer_size().unwrap().width as f64) / 2.0,
+      y: dock.outer_position().unwrap().y as f64
+        - window.outer_size().unwrap().height as f64
         - margin_bottom,
     })
     .ok();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,8 +35,7 @@
         "decorations": false,
         "resizable": false,
         "fullscreen": false,
-        "transparent": true,
-        "acceptFirstMouse": true
+        "transparent": true
       },
       {
         "title": "Recording Input Options",
@@ -48,7 +47,6 @@
         "resizable": false,
         "shadow": true,
         "transparent": true,
-        "acceptFirstMouse": true,
         "visible": false,
         "windowEffects": {
           "effects": ["underWindowBackground"],

--- a/src/app/pages/recording-input-options.tsx
+++ b/src/app/pages/recording-input-options.tsx
@@ -5,6 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import { isRecordingInputOptionsOpen } from "../../api/windows";
 import InputAudioSelect from "../../features/audio-inputs/components/input-audio-select";
 import CameraSelect from "../../features/camera-select/components/camera-select";
+import { clearInteractionAttributes } from "../../lib/styling";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -30,6 +31,7 @@ const RecordingInputOptions = () => {
     void addWindowToStore();
 
     const unlisten = listen(Events.RecordingInputOptionsOpened, () => {
+      clearInteractionAttributes();
       setWindowOpenState(AppWindow.RecordingInputOptions, true);
     });
     const unlistenClose = listen(Events.ClosedRecordingInputOptions, () => {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -11,7 +11,6 @@ const buttonVariants = tv({
   base: [
     "inline-flex items-center gap-2 rounded-md font-semibold transition",
     focusStyles,
-    elementFocus,
   ],
   compoundVariants: [
     {
@@ -35,6 +34,7 @@ const buttonVariants = tv({
   ],
   defaultVariants: {
     color: "neutral",
+    showFocus: true,
     size: "md",
     type: "solid",
   },
@@ -62,6 +62,7 @@ const buttonVariants = tv({
         "mask-[linear-gradient(-75deg,var(--color-content)_calc(var(--x)_+_20%),transparent_calc(var(--x)_+_30%),var(--color-content)_calc(var(--x)_+_100%))]",
       ],
     },
+    showFocus: { true: elementFocus },
     size: {
       lg: "text-md px-4 py-2",
       md: "text-sm px-3 py-2",
@@ -109,6 +110,7 @@ const Button = ({
   className,
   color,
   shiny,
+  showFocus,
   size,
   variant,
   ...props
@@ -121,6 +123,7 @@ const Button = ({
         className,
         color,
         shiny,
+        showFocus,
         size,
         variant,
       })}

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -25,6 +25,7 @@ const ICON_SIZES = {
 
 const selectVariants = tv({
   defaultVariants: {
+    showFocus: true,
     size: "md",
     variant: "solid",
   },
@@ -33,13 +34,17 @@ const selectVariants = tv({
     controls: "text-muted/75",
     label: "text-muted font-medium",
     trigger: [
-      "shrink inline-flex flex-row items-center justify-between text-content-fg gap-4 rounded-md transition-colors",
+      "outline-none shrink inline-flex flex-row items-center justify-between text-content-fg gap-4 rounded-md transition-colors",
       "data-[hovered]:bg-neutral/50",
       focusStyles,
-      elementFocus,
     ],
   },
   variants: {
+    showFocus: {
+      true: {
+        trigger: elementFocus,
+      },
+    },
     size: {
       md: { label: "text-sm", trigger: "text-sm pl-3 pr-2 py-2" },
       sm: { label: "text-xs", trigger: "text-xs pl-3 pr-2 py-2" },
@@ -86,6 +91,7 @@ const Select = <T extends object>({
   onClear,
   onPress,
   placeholder,
+  showFocus,
   size,
   standalone,
   triggerRef,
@@ -108,7 +114,7 @@ const Select = <T extends object>({
           <div className="relative">
             <Button
               ref={triggerRef}
-              className={trigger({ className })}
+              className={trigger({ className, showFocus })}
               onPress={onPress}
             >
               <div className="inline-flex flex-row items-center gap-2 flex-1 min-w-0">

--- a/src/components/shared/input-select/input-select.tsx
+++ b/src/components/shared/input-select/input-select.tsx
@@ -91,6 +91,7 @@ const InputSelect = ({
       items={listBox?.selectedItems ?? []}
       placeholder={placeholder}
       selectedKey={selectedItem(listBox?.selectedItems ?? [])}
+      showFocus={false}
       size="sm"
       triggerRef={triggerRef}
       variant="ghost"

--- a/src/features/camera-select/components/camera-select.tsx
+++ b/src/features/camera-select/components/camera-select.tsx
@@ -41,6 +41,13 @@ const CameraSelect = () => {
     return cameras.map(({ index, name }) => ({ id: index, label: name }));
   };
 
+  const clearCanvas = () => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d", { willReadFrequently: false });
+    if (!canvas || !ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
   const processFrame = (buffer: ArrayBuffer) => {
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d", { willReadFrequently: false });
@@ -66,6 +73,7 @@ const CameraSelect = () => {
 
   const onChange = async (selectedItems: Item[], isDockOpen: boolean) => {
     await stopCameraStream();
+    clearCanvas();
     if (!isDockOpen) return;
 
     const selectedDevice = selectedItem(selectedItems);

--- a/src/features/recording-controls/components/icon-radio.tsx
+++ b/src/features/recording-controls/components/icon-radio.tsx
@@ -5,15 +5,10 @@ import {
 import { VariantProps } from "tailwind-variants";
 
 import { tv } from "../../../../tailwind-merge.config";
-import { elementFocus, focusStyles } from "../../../lib/styling";
 
 const radioVariants = tv({
   slots: {
-    base: [
-      "group relative flex flex-col grow items-center p-2 rounded-md transition select-none",
-      focusStyles,
-      elementFocus,
-    ],
+    base: "group relative flex flex-col grow items-center p-2 rounded-md transition select-none",
     icon: [
       "text-muted transition-colors",
       "group-data-[hovered]:text-content-fg/75",

--- a/src/features/recording-controls/components/input-toggle.tsx
+++ b/src/features/recording-controls/components/input-toggle.tsx
@@ -33,6 +33,7 @@ const InputToggle = ({
     <Button
       className="cursor-default relative p-1 transition-transform transform data-[hovered]:scale-110"
       onPress={onToggle}
+      showFocus={false}
       variant="ghost"
     >
       <div className="invisible">{onIcon}</div>

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -26,6 +26,7 @@ import Keyboard from "../../../components/keyboard/keyboard";
 import RadioGroup from "../../../components/radio-group/radio-group";
 import Separator from "../../../components/separator/separator";
 import Sparkles from "../../../components/sparkles/sparkles";
+import { clearInteractionAttributes } from "../../../lib/styling";
 import { usePermissionsStore } from "../../../stores/permissions.store";
 import {
   AppWindow,
@@ -49,12 +50,14 @@ const RecordingControls = () => {
   );
 
   const onCancel = () => {
+    clearInteractionAttributes();
     setWindowOpenState(AppWindow.StartRecordingDock, false);
     hideStartRecordingDock();
   };
 
   const onClickOptions = async () => {
     if (!optionsButtonRef.current) return;
+    clearInteractionAttributes();
 
     const { left, width } = optionsButtonRef.current.getBoundingClientRect();
     const currentWindow = getCurrentWindow();
@@ -69,6 +72,7 @@ const RecordingControls = () => {
       <Button
         className="self-stretch cursor-default group"
         onPress={onCancel}
+        showFocus={false}
         variant="ghost"
       >
         <div className="flex flex-col gap-1 items-center">
@@ -151,6 +155,7 @@ const RecordingControls = () => {
         <Button
           ref={optionsButtonRef}
           className="justify-center transition-transform transform data-[hovered]:scale-110"
+          showFocus={false}
           size="sm"
           variant="ghost"
           onPress={() => {
@@ -167,7 +172,11 @@ const RecordingControls = () => {
         scale={{ max: 0.5, min: 0.2 }}
         sparklesCount={2}
       >
-        <Button className="self-stretch cursor-default group" variant="ghost">
+        <Button
+          className="self-stretch cursor-default group"
+          showFocus={false}
+          variant="ghost"
+        >
           <div className="flex flex-col gap-1 items-center">
             <Circle
               className="group-data-[hovered]:scale-110 transform transition-transform"

--- a/src/lib/styling.ts
+++ b/src/lib/styling.ts
@@ -18,5 +18,19 @@ export const focusStyles = "outline-none ring-content-fg ring-offset-content";
 
 export const elementFocus =
   "data-[focus-visible]:ring-offset-1 data-[focus-visible]:ring-1";
+
 export const groupFocus =
   "group-data-[focus-visible]:ring-offset-1 group-data-[focus-visible]:ring-1";
+
+/**
+ * Remove `data-hovered`, `data-focused`, and `data-focus-visible` attributes on element with data-focused.
+ */
+export const clearInteractionAttributes = () => {
+  const activeElement = document.querySelector('[data-focused="true"]');
+  if (activeElement && activeElement instanceof HTMLElement) {
+    activeElement.blur();
+    activeElement.removeAttribute("data-hovered");
+    activeElement.removeAttribute("data-focused");
+    activeElement.removeAttribute("data-focus-visible");
+  }
+};


### PR DESCRIPTION
Two-pronged approach.
- Clear react-aria attributes when opening a new panel or closing the panel.
- Remove focus styles on dock elements. No consistent way to prevent focus showing when clicking after panel reopened.