### PR TITLE
Handle input toggles when the source does not exist

### DIFF
--- a/src-tauri/src/camera/mod.rs
+++ b/src-tauri/src/camera/mod.rs
@@ -1,3 +1,2 @@
 pub mod commands;
-mod models;
 mod service;

--- a/src-tauri/src/camera/models.rs
+++ b/src-tauri/src/camera/models.rs
@@ -1,7 +1,0 @@
-use serde::Serialize;
-
-#[derive(Debug, Clone, Serialize)]
-pub struct CameraDetails {
-  pub index: String,
-  pub name: String,
-}

--- a/src/components/shared/input-select/input-select.tsx
+++ b/src/components/shared/input-select/input-select.tsx
@@ -24,7 +24,7 @@ type InputSelectProps = {
   icon?: React.ReactNode;
   onChange?: (
     selectedItems: Item[],
-    isDockOpen: boolean
+    isPanelOpen: boolean
   ) => void | Promise<void>;
 };
 const InputSelect = ({
@@ -90,7 +90,7 @@ const InputSelect = ({
       isOpen={openListBoxId === id}
       items={listBox?.selectedItems ?? []}
       placeholder={placeholder}
-      selectedKey={selectedItem(listBox?.selectedItems ?? [])}
+      selectedKey={selectedItem(listBox?.selectedItems ?? [])?.id ?? null}
       showFocus={false}
       size="sm"
       triggerRef={triggerRef}

--- a/src/features/audio-inputs/components/archive/system-audio-toggle.tsx
+++ b/src/features/audio-inputs/components/archive/system-audio-toggle.tsx
@@ -4,23 +4,22 @@ import { Volume2Icon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
-import Switch from "../../../components/switch/switch";
-import { cn } from "../../../lib/styling";
-import { useRecordingPreferencesStore } from "../../../stores/recording-preferences.store";
+import Switch from "../../../../components/switch/switch";
+import { cn } from "../../../../lib/styling";
+import { useRecordingPreferencesStore } from "../../../../stores/recording-preferences.store";
 import {
   AppWindow,
   useWindowReopenStore,
-} from "../../../stores/window-open-state.store";
-import { Events } from "../../../types/events";
+} from "../../../../stores/window-open-state.store";
+import { Events } from "../../../../types/events";
 import {
   AudioStream,
   AudioStreamChannel,
   startAudioListener,
   stopAudioListener,
-} from "../api/audio-listeners";
-import { usePeak } from "../hooks/use-peak";
-
-import AudioMeter from "./audio-meter";
+} from "../../api/audio-listeners";
+import { usePeak } from "../../hooks/use-peak";
+import AudioMeter from "../audio-meter";
 
 const SystemAudioToggle = () => {
   const channel = useRef<Channel<AudioStreamChannel>>(null);

--- a/src/features/audio-inputs/components/input-audio-select.tsx
+++ b/src/features/audio-inputs/components/input-audio-select.tsx
@@ -54,7 +54,7 @@ const InputAudioSelect = () => {
     setDecibels(undefined);
     if (!isDockOpen) return;
 
-    const selectedDevice = selectedItem(selectedItems);
+    const selectedDevice = selectedItem(selectedItems)?.id;
     if (selectedDevice) {
       setNoDevice(false);
       channel.current = new Channel<AudioStreamChannel>();

--- a/src/features/camera-select/api/camera.ts
+++ b/src/features/camera-select/api/camera.ts
@@ -1,24 +1,12 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { z } from "zod";
 
 import { Commands } from "../../../types/api";
 
-const CameraDetailSchema = z.object({
-  index: z.coerce.number(),
-  name: z.string(),
-});
+export const listCameras = async (): Promise<string[]> =>
+  await invoke(Commands.ListCameras);
 
-const CameraDetailsSchema = z.array(CameraDetailSchema);
-
-type CameraDetail = z.infer<typeof CameraDetailSchema>;
-
-export const listCameras = async (): Promise<CameraDetail[]> => {
-  const response = await invoke(Commands.ListCameras);
-  return CameraDetailsSchema.parse(response);
-};
-
-export const startCameraStream = (deviceIndex: number, channel: Channel) => {
-  void invoke(Commands.StartCameraStream, { channel, deviceIndex });
+export const startCameraStream = (name: string, channel: Channel) => {
+  void invoke(Commands.StartCameraStream, { channel, name });
 };
 
 export const stopCameraStream = async () => {

--- a/src/features/recording-controls/components/input-toggle-groups.tsx
+++ b/src/features/recording-controls/components/input-toggle-groups.tsx
@@ -1,0 +1,79 @@
+import {
+  Camera,
+  CameraOff,
+  Mic,
+  MicOff,
+  Volume2,
+  VolumeOff,
+} from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+
+import { usePermissionsStore } from "../../../stores/permissions.store";
+import { useRecordingPreferencesStore } from "../../../stores/recording-preferences.store";
+
+import InputToggle from "./input-toggle";
+
+type InputToggleGroupProps = {
+  openRecordingInputOptions: () => Promise<void>;
+};
+const InputToggleGroup = ({
+  openRecordingInputOptions,
+}: InputToggleGroupProps) => {
+  const permissions = usePermissionsStore((state) => state.permissions);
+  const [
+    camera,
+    setCamera,
+    microphone,
+    setMicrophone,
+    systemAudio,
+    setSystemAudio,
+  ] = useRecordingPreferencesStore(
+    useShallow((state) => [
+      state.camera,
+      state.setCamera,
+      state.microphone,
+      state.setMicrophone,
+      state.systemAudio,
+      state.setSystemAudio,
+    ])
+  );
+
+  return (
+    <div className="flex flex-row justify-between px-2 text-content-fg">
+      {permissions.screen && (
+        <InputToggle
+          offIcon={<VolumeOff size={16} />}
+          onIcon={<Volume2 size={16} />}
+          openRecordingInputOptions={openRecordingInputOptions}
+          permission={permissions.screen}
+          setValue={setSystemAudio}
+          value={systemAudio}
+        />
+      )}
+
+      {permissions.microphone && (
+        <InputToggle
+          offIcon={<MicOff size={16} />}
+          onIcon={<Mic size={16} />}
+          openRecordingInputOptions={openRecordingInputOptions}
+          permission={permissions.microphone}
+          setValue={setMicrophone}
+          value={microphone}
+        />
+      )}
+
+      {permissions.camera && (
+        <InputToggle
+          offIcon={<CameraOff size={16} />}
+          onIcon={<Camera size={16} />}
+          openRecordingInputOptions={openRecordingInputOptions}
+          permission={permissions.camera}
+          setValue={setCamera}
+          value={camera}
+        />
+      )}
+    </div>
+  );
+};
+
+export default InputToggleGroup;

--- a/src/features/recording-controls/components/input-toggle.tsx
+++ b/src/features/recording-controls/components/input-toggle.tsx
@@ -7,18 +7,18 @@ import { PermissionStatus } from "../../../stores/permissions.store";
 type InputToggleProps = {
   offIcon: React.ReactNode;
   onIcon: React.ReactNode;
+  openRecordingInputOptions: () => Promise<void>;
   permission: PermissionStatus;
   setValue: (value: boolean) => void;
-  showRecordingInputOptions: () => void;
   value: boolean;
   showWarning?: boolean;
 };
 const InputToggle = ({
   offIcon,
   onIcon,
+  openRecordingInputOptions,
   permission,
   setValue,
-  showRecordingInputOptions,
   showWarning,
   value,
 }: InputToggleProps) => {
@@ -30,7 +30,7 @@ const InputToggle = ({
 
   const onToggle = () => {
     if (permission.hasAccess) setValue(!value);
-    else showRecordingInputOptions();
+    else void openRecordingInputOptions();
   };
 
   return (

--- a/src/features/recording-controls/components/input-toggle.tsx
+++ b/src/features/recording-controls/components/input-toggle.tsx
@@ -29,7 +29,7 @@ const InputToggle = ({
   };
 
   const onToggle = () => {
-    if (permission.hasAccess) setValue(!value);
+    if (permission.hasAccess && !showWarning) setValue(!value);
     else void openRecordingInputOptions();
   };
 

--- a/src/features/recording-controls/components/input-toggle.tsx
+++ b/src/features/recording-controls/components/input-toggle.tsx
@@ -1,8 +1,10 @@
-import { TriangleAlert } from "lucide-react";
+import { CircleOff, TriangleAlert } from "lucide-react";
 import { AnimatePresence, motion, MotionProps } from "motion/react";
 
 import Button from "../../../components/button/button";
 import { PermissionStatus } from "../../../stores/permissions.store";
+
+import { WarningType } from "./input-toggle-groups";
 
 type InputToggleProps = {
   offIcon: React.ReactNode;
@@ -11,7 +13,7 @@ type InputToggleProps = {
   permission: PermissionStatus;
   setValue: (value: boolean) => void;
   value: boolean;
-  showWarning?: boolean;
+  warning?: WarningType;
 };
 const InputToggle = ({
   offIcon,
@@ -19,8 +21,8 @@ const InputToggle = ({
   openRecordingInputOptions,
   permission,
   setValue,
-  showWarning,
   value,
+  warning,
 }: InputToggleProps) => {
   const animationProps: MotionProps = {
     animate: { opacity: 1, scale: 1 },
@@ -29,7 +31,8 @@ const InputToggle = ({
   };
 
   const onToggle = () => {
-    if (permission.hasAccess && !showWarning) setValue(!value);
+    if (permission.hasAccess && warning !== WarningType.Disconnected)
+      setValue(!value);
     else void openRecordingInputOptions();
   };
 
@@ -41,16 +44,21 @@ const InputToggle = ({
       variant="ghost"
     >
       <AnimatePresence>
-        {showWarning && (
-          <motion.div
-            animate={{ opacity: 1, y: 0 }}
-            className="absolute text-warning -top-3"
-            exit={{ opacity: 0, y: -5 }}
-            initial={{ opacity: 0, y: -5 }}
-          >
-            <TriangleAlert size={12} />
-          </motion.div>
-        )}
+        {warning &&
+          ((warning === WarningType.Empty && value) ||
+            warning === WarningType.Disconnected) && (
+            <motion.div
+              animate={{ opacity: 1, y: 0 }}
+              className="absolute text-warning -top-3"
+              exit={{ opacity: 0, y: -5 }}
+              initial={{ opacity: 0, y: -5 }}
+            >
+              {warning === WarningType.Disconnected && (
+                <TriangleAlert size={12} />
+              )}
+              {warning === WarningType.Empty && <CircleOff size={12} />}
+            </motion.div>
+          )}
       </AnimatePresence>
 
       <div className="invisible">{onIcon}</div>

--- a/src/features/recording-controls/components/input-toggle.tsx
+++ b/src/features/recording-controls/components/input-toggle.tsx
@@ -1,5 +1,5 @@
+import { TriangleAlert } from "lucide-react";
 import { AnimatePresence, motion, MotionProps } from "motion/react";
-import { useState } from "react";
 
 import Button from "../../../components/button/button";
 import { PermissionStatus } from "../../../stores/permissions.store";
@@ -8,16 +8,20 @@ type InputToggleProps = {
   offIcon: React.ReactNode;
   onIcon: React.ReactNode;
   permission: PermissionStatus;
+  setValue: (value: boolean) => void;
   showRecordingInputOptions: () => void;
+  value: boolean;
+  showWarning?: boolean;
 };
 const InputToggle = ({
   offIcon,
   onIcon,
   permission,
+  setValue,
   showRecordingInputOptions,
+  showWarning,
+  value,
 }: InputToggleProps) => {
-  const [isOn, setIsOn] = useState(false);
-
   const animationProps: MotionProps = {
     animate: { opacity: 1, scale: 1 },
     exit: { opacity: 0, scale: 0 },
@@ -25,21 +29,34 @@ const InputToggle = ({
   };
 
   const onToggle = () => {
-    if (permission.hasAccess) setIsOn((prev) => !prev);
+    if (permission.hasAccess) setValue(!value);
     else showRecordingInputOptions();
   };
 
   return (
     <Button
-      className="cursor-default relative p-1 transition-transform transform data-[hovered]:scale-110"
+      className="cursor-default relative p-1 transition-transform transform data-[hovered]:scale-110 justify-center"
       onPress={onToggle}
       showFocus={false}
       variant="ghost"
     >
+      <AnimatePresence>
+        {showWarning && (
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            className="absolute text-warning -top-3"
+            exit={{ opacity: 0, y: -5 }}
+            initial={{ opacity: 0, y: -5 }}
+          >
+            <TriangleAlert size={12} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <div className="invisible">{onIcon}</div>
 
       <AnimatePresence>
-        {isOn ? (
+        {value ? (
           <motion.div key="on" {...animationProps} className="absolute">
             {onIcon}
           </motion.div>

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -1,18 +1,5 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import {
-  AppWindowMac,
-  Camera,
-  CameraOff,
-  Circle,
-  CircleX,
-  Mic,
-  MicOff,
-  Monitor,
-  Sparkle,
-  SquareDashed,
-  Volume2,
-  VolumeOff,
-} from "lucide-react";
+import { Circle, CircleX, Sparkle } from "lucide-react";
 import { ComponentProps, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 
@@ -22,22 +9,16 @@ import {
 } from "../../../api/windows";
 import Button from "../../../components/button/button";
 import Keyboard from "../../../components/keyboard/keyboard";
-import RadioGroup from "../../../components/radio-group/radio-group";
 import Separator from "../../../components/separator/separator";
 import Sparkles from "../../../components/sparkles/sparkles";
 import { clearInteractionAttributes } from "../../../lib/styling";
-import { usePermissionsStore } from "../../../stores/permissions.store";
-import {
-  RecordingType,
-  useRecordingPreferencesStore,
-} from "../../../stores/recording-preferences.store";
 import {
   AppWindow,
   useWindowReopenStore,
 } from "../../../stores/window-open-state.store";
 
-import IconRadio from "./icon-radio";
-import InputToggle from "./input-toggle";
+import InputToggleGroup from "./input-toggle-groups";
+import RecordingTypeRadioGroup from "./recording-type-radio-group";
 
 const KEYBOARD_STYLE: ComponentProps<typeof Keyboard> = {
   size: "xs",
@@ -45,29 +26,6 @@ const KEYBOARD_STYLE: ComponentProps<typeof Keyboard> = {
 };
 
 const RecordingControls = () => {
-  const permissions = usePermissionsStore((state) => state.permissions);
-  const [
-    recordingType,
-    setRecordingType,
-    camera,
-    setCamera,
-    microphone,
-    setMicrophone,
-    systemAudio,
-    setSystemAudio,
-  ] = useRecordingPreferencesStore(
-    useShallow((state) => [
-      state.recordingType,
-      state.setRecordingType,
-      state.camera,
-      state.setCamera,
-      state.microphone,
-      state.setMicrophone,
-      state.systemAudio,
-      state.setSystemAudio,
-    ])
-  );
-
   const optionsButtonRef = useRef<HTMLButtonElement>(null);
   const setWindowOpenState = useWindowReopenStore(
     useShallow((state) => state.setWindowOpenState)
@@ -79,7 +37,7 @@ const RecordingControls = () => {
     hideStartRecordingDock();
   };
 
-  const onClickOptions = async () => {
+  const openRecordingInputOptions = async () => {
     if (!optionsButtonRef.current) return;
     clearInteractionAttributes();
 
@@ -107,83 +65,14 @@ const RecordingControls = () => {
 
       <Separator className="h-[60px]" orientation="vertical" spacing="sm" />
 
-      <RadioGroup
-        aria-label="Recording type"
-        className="grow"
-        orientation="horizontal"
-        value={recordingType}
-        onChange={(value) => {
-          setRecordingType(value as RecordingType);
-        }}
-      >
-        <IconRadio
-          aria-label="Region"
-          icon={<SquareDashed size={30} />}
-          shortcut={<Keyboard {...KEYBOARD_STYLE}>1</Keyboard>}
-          subtext="Region"
-          value={RecordingType.Region}
-        />
-
-        <IconRadio
-          aria-label="Window"
-          icon={<AppWindowMac size={30} />}
-          shortcut={<Keyboard {...KEYBOARD_STYLE}>2</Keyboard>}
-          subtext="Window"
-          value={RecordingType.Window}
-        />
-
-        <IconRadio
-          aria-label="Screen"
-          icon={<Monitor size={30} />}
-          shortcut={<Keyboard {...KEYBOARD_STYLE}>3</Keyboard>}
-          subtext="Screen"
-          value={RecordingType.Screen}
-        />
-      </RadioGroup>
+      <RecordingTypeRadioGroup />
 
       <Separator className="h-[60px]" orientation="vertical" spacing="sm" />
 
       <div className="flex flex-col min-w-24 mr-2">
-        <div className="flex flex-row justify-between px-2 text-content-fg">
-          {permissions.screen && (
-            <InputToggle
-              offIcon={<VolumeOff size={16} />}
-              onIcon={<Volume2 size={16} />}
-              permission={permissions.screen}
-              setValue={setSystemAudio}
-              value={systemAudio}
-              showRecordingInputOptions={() => {
-                void onClickOptions();
-              }}
-            />
-          )}
-
-          {permissions.microphone && (
-            <InputToggle
-              offIcon={<MicOff size={16} />}
-              onIcon={<Mic size={16} />}
-              permission={permissions.microphone}
-              setValue={setMicrophone}
-              value={microphone}
-              showRecordingInputOptions={() => {
-                void onClickOptions();
-              }}
-            />
-          )}
-
-          {permissions.camera && (
-            <InputToggle
-              offIcon={<CameraOff size={16} />}
-              onIcon={<Camera size={16} />}
-              permission={permissions.camera}
-              setValue={setCamera}
-              value={camera}
-              showRecordingInputOptions={() => {
-                void onClickOptions();
-              }}
-            />
-          )}
-        </div>
+        <InputToggleGroup
+          openRecordingInputOptions={openRecordingInputOptions}
+        />
 
         <Button
           ref={optionsButtonRef}
@@ -192,7 +81,7 @@ const RecordingControls = () => {
           size="sm"
           variant="ghost"
           onPress={() => {
-            void onClickOptions();
+            void openRecordingInputOptions();
           }}
         >
           Options

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -5,7 +5,6 @@ import {
   CameraOff,
   Circle,
   CircleX,
-  Cog,
   Mic,
   MicOff,
   Monitor,
@@ -29,6 +28,10 @@ import Sparkles from "../../../components/sparkles/sparkles";
 import { clearInteractionAttributes } from "../../../lib/styling";
 import { usePermissionsStore } from "../../../stores/permissions.store";
 import {
+  RecordingType,
+  useRecordingPreferencesStore,
+} from "../../../stores/recording-preferences.store";
+import {
   AppWindow,
   useWindowReopenStore,
 } from "../../../stores/window-open-state.store";
@@ -43,6 +46,27 @@ const KEYBOARD_STYLE: ComponentProps<typeof Keyboard> = {
 
 const RecordingControls = () => {
   const permissions = usePermissionsStore((state) => state.permissions);
+  const [
+    recordingType,
+    setRecordingType,
+    camera,
+    setCamera,
+    microphone,
+    setMicrophone,
+    systemAudio,
+    setSystemAudio,
+  ] = useRecordingPreferencesStore(
+    useShallow((state) => [
+      state.recordingType,
+      state.setRecordingType,
+      state.camera,
+      state.setCamera,
+      state.microphone,
+      state.setMicrophone,
+      state.systemAudio,
+      state.setSystemAudio,
+    ])
+  );
 
   const optionsButtonRef = useRef<HTMLButtonElement>(null);
   const setWindowOpenState = useWindowReopenStore(
@@ -86,15 +110,18 @@ const RecordingControls = () => {
       <RadioGroup
         aria-label="Recording type"
         className="grow"
-        defaultValue="region"
         orientation="horizontal"
+        value={recordingType}
+        onChange={(value) => {
+          setRecordingType(value as RecordingType);
+        }}
       >
         <IconRadio
           aria-label="Region"
           icon={<SquareDashed size={30} />}
           shortcut={<Keyboard {...KEYBOARD_STYLE}>1</Keyboard>}
           subtext="Region"
-          value="region"
+          value={RecordingType.Region}
         />
 
         <IconRadio
@@ -102,7 +129,7 @@ const RecordingControls = () => {
           icon={<AppWindowMac size={30} />}
           shortcut={<Keyboard {...KEYBOARD_STYLE}>2</Keyboard>}
           subtext="Window"
-          value="window"
+          value={RecordingType.Window}
         />
 
         <IconRadio
@@ -110,7 +137,7 @@ const RecordingControls = () => {
           icon={<Monitor size={30} />}
           shortcut={<Keyboard {...KEYBOARD_STYLE}>3</Keyboard>}
           subtext="Screen"
-          value="screen"
+          value={RecordingType.Screen}
         />
       </RadioGroup>
 
@@ -123,6 +150,8 @@ const RecordingControls = () => {
               offIcon={<VolumeOff size={16} />}
               onIcon={<Volume2 size={16} />}
               permission={permissions.screen}
+              setValue={setSystemAudio}
+              value={systemAudio}
               showRecordingInputOptions={() => {
                 void onClickOptions();
               }}
@@ -134,6 +163,8 @@ const RecordingControls = () => {
               offIcon={<MicOff size={16} />}
               onIcon={<Mic size={16} />}
               permission={permissions.microphone}
+              setValue={setMicrophone}
+              value={microphone}
               showRecordingInputOptions={() => {
                 void onClickOptions();
               }}
@@ -145,6 +176,8 @@ const RecordingControls = () => {
               offIcon={<CameraOff size={16} />}
               onIcon={<Camera size={16} />}
               permission={permissions.camera}
+              setValue={setCamera}
+              value={camera}
               showRecordingInputOptions={() => {
                 void onClickOptions();
               }}

--- a/src/features/recording-controls/components/recording-type-radio-group.tsx
+++ b/src/features/recording-controls/components/recording-type-radio-group.tsx
@@ -1,0 +1,61 @@
+import { AppWindowMac, Monitor, SquareDashed } from "lucide-react";
+import { ComponentProps } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import Keyboard from "../../../components/keyboard/keyboard";
+import RadioGroup from "../../../components/radio-group/radio-group";
+import {
+  RecordingType,
+  useRecordingPreferencesStore,
+} from "../../../stores/recording-preferences.store";
+
+import IconRadio from "./icon-radio";
+
+const KEYBOARD_STYLE: ComponentProps<typeof Keyboard> = {
+  size: "xs",
+  variant: "ghost",
+};
+
+const RecordingTypeRadioGroup = () => {
+  const [recordingType, setRecordingType] = useRecordingPreferencesStore(
+    useShallow((state) => [state.recordingType, state.setRecordingType])
+  );
+
+  return (
+    <RadioGroup
+      aria-label="Recording type"
+      className="grow"
+      orientation="horizontal"
+      value={recordingType}
+      onChange={(value) => {
+        setRecordingType(value as RecordingType);
+      }}
+    >
+      <IconRadio
+        aria-label="Region"
+        icon={<SquareDashed size={30} />}
+        shortcut={<Keyboard {...KEYBOARD_STYLE}>1</Keyboard>}
+        subtext="Region"
+        value={RecordingType.Region}
+      />
+
+      <IconRadio
+        aria-label="Window"
+        icon={<AppWindowMac size={30} />}
+        shortcut={<Keyboard {...KEYBOARD_STYLE}>2</Keyboard>}
+        subtext="Window"
+        value={RecordingType.Window}
+      />
+
+      <IconRadio
+        aria-label="Screen"
+        icon={<Monitor size={30} />}
+        shortcut={<Keyboard {...KEYBOARD_STYLE}>3</Keyboard>}
+        subtext="Screen"
+        value={RecordingType.Screen}
+      />
+    </RadioGroup>
+  );
+};
+
+export default RecordingTypeRadioGroup;

--- a/src/stores/recording-preferences.store.ts
+++ b/src/stores/recording-preferences.store.ts
@@ -3,7 +3,19 @@ import { devtools, persist } from "zustand/middleware";
 
 const STORE_NAME = "recordingPreferences";
 
+export enum RecordingType {
+  Region = "region",
+  Window = "window",
+  Screen = "screen",
+}
+
 type RecordingPreferencesState = {
+  camera: boolean;
+  microphone: boolean;
+  recordingType: RecordingType;
+  setCamera: (camera: boolean) => void;
+  setMicrophone: (microphone: boolean) => void;
+  setRecordingType: (recordingType: RecordingType) => void;
   setSystemAudio: (systemAudio: boolean) => void;
   systemAudio: boolean;
 };
@@ -12,7 +24,19 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
   devtools(
     persist(
       (set) => ({
-        setSystemAudio: (systemAudio: boolean) => {
+        camera: false,
+        microphone: false,
+        recordingType: RecordingType.Region,
+        setCamera: (camera) => {
+          set({ camera });
+        },
+        setMicrophone: (microphone) => {
+          set({ microphone });
+        },
+        setRecordingType: (recordingType) => {
+          set({ recordingType });
+        },
+        setSystemAudio: (systemAudio) => {
           set({ systemAudio });
         },
         systemAudio: false,

--- a/src/stores/standalone-listbox.store.ts
+++ b/src/stores/standalone-listbox.store.ts
@@ -143,5 +143,5 @@ export const updateStandaloneListBoxStore = (e: StorageEvent) => {
  */
 export const selectedItem = (selectedItems: Item[]) => {
   if (selectedItems.length === 0) return null;
-  return selectedItems[0].id;
+  return selectedItems[0];
 };

--- a/src/stores/window-open-state.store.ts
+++ b/src/stores/window-open-state.store.ts
@@ -46,3 +46,10 @@ export const useWindowReopenStore = create<WindowOpenState>()(
     )
   )
 );
+
+export const rehydrateWindowReopenState = (e: StorageEvent) => {
+  const { key } = e;
+  if (key === STORE_NAME) {
+    void useWindowReopenStore.persist.rehydrate();
+  }
+};


### PR DESCRIPTION
Introduce 2 warning symbols above the microphone and camera toggles:
- Disconnected - device no longer exists since last time the dock was opened,
- Empty - although the toggle is on no device is configured.

Also a bug fix around using camera indices. On MacOS these are not consistent, meaning at one moment camera 1 may be index 0, and at another time it could be index 1. Now the `human_name` is used which is more reliable.