### PR TITLE
Replace Physical position and size with Logical

### DIFF
--- a/src/api/windows.ts
+++ b/src/api/windows.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
 
 import { Commands } from "../types/api";
 
@@ -14,17 +15,15 @@ export const hideStartRecordingDock = () => {
   void invoke(Commands.HideStartRecordingDock);
 };
 
-type ShowStandaloneListBoxProps = { width: number; x: number; y: number };
-export const showStandaloneListBox = async ({
-  width,
-  x,
-  y,
-}: ShowStandaloneListBoxProps) => {
+export const showStandaloneListBox = async (
+  parentWindowLabel: string,
+  offset: LogicalPosition,
+  size: LogicalSize
+) => {
   await invoke(Commands.ShowStandaloneListBox, {
-    height: 100,
-    width,
-    x,
-    y,
+    offset,
+    parentWindowLabel,
+    size,
   });
 };
 
@@ -32,6 +31,7 @@ export const isStartRecordingDockOpen = async (): Promise<boolean> => {
   return await invoke(Commands.IsStartRecordingDockOpen);
 };
 
+/** `x` coordinate is the logical coordinate. */
 export const showRecordingInputOptions = (x: number) => {
   void invoke(Commands.ShowRecordingInputOptions, { x });
 };

--- a/src/app/pages/listbox-standalone.tsx
+++ b/src/app/pages/listbox-standalone.tsx
@@ -1,4 +1,4 @@
-import { getCurrentWindow, PhysicalSize } from "@tauri-apps/api/window";
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { Selection } from "react-aria-components";
 import { useShallow } from "zustand/react/shallow";
@@ -43,10 +43,10 @@ const StandaloneListBox = () => {
    * No way to know ahead of time.
    */
   const adjustWebviewHeight = async (height: number) => {
-    const finalHeight =
-      (Math.min(height, MAX_HEIGHT) + PADDING) * devicePixelRatio;
-    const { width } = await webview.innerSize();
-    await webview.setSize(new PhysicalSize(width, finalHeight));
+    const finalHeight = Math.min(height, MAX_HEIGHT) + PADDING;
+    const scaleFactor = await webview.scaleFactor();
+    const { width } = (await webview.innerSize()).toLogical(scaleFactor);
+    await webview.setSize(new LogicalSize(width, finalHeight));
   };
 
   useEffect(() => {

--- a/src/components/shared/input-select/input-select.tsx
+++ b/src/components/shared/input-select/input-select.tsx
@@ -1,4 +1,8 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  getCurrentWindow,
+  LogicalPosition,
+  LogicalSize,
+} from "@tauri-apps/api/window";
 import { useEffect, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 
@@ -60,14 +64,14 @@ const InputSelect = ({
       triggerRef.current.getBoundingClientRect();
     const currentWindow = getCurrentWindow();
 
-    const { x, y } = await currentWindow.outerPosition();
-
     const PADDING = 4;
-    await showStandaloneListBox({
-      width,
-      x: x + left * window.devicePixelRatio,
-      y: y + (top + height + PADDING) * window.devicePixelRatio,
-    });
+    await showStandaloneListBox(
+      currentWindow.label,
+      new LogicalPosition(left, top + height + PADDING),
+      // Height as 1 as standalone listbox auto resizes on open - value has to
+      // > 0 for proper positioning
+      new LogicalSize(width, 1)
+    );
 
     const items = await fetchItems();
     setItems(id, items);

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -43,10 +43,11 @@ const RecordingControls = () => {
 
     const { left, width } = optionsButtonRef.current.getBoundingClientRect();
     const currentWindow = getCurrentWindow();
-    const { x } = await currentWindow.outerPosition();
+    const scaleFactor = await currentWindow.scaleFactor();
+    const { x } = (await currentWindow.outerPosition()).toLogical(scaleFactor);
 
     // Position at center x of options button,
-    showRecordingInputOptions(x + (left + width / 2) * window.devicePixelRatio);
+    showRecordingInputOptions(x + (left + width / 2));
   };
 
   return (


### PR DESCRIPTION
Standardise the coordinate system being used, Physical coords make it difficult to use with multiple monitors as the coordinates use logical values.

This change will ensure consistency across scale factors and makes the conversion explicit.