### PR TITLE
Monitor selection

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -698,7 +698,17 @@ name = "cidre"
 version = "0.7.0"
 source = "git+https://github.com/yury/cidre.git?rev=561036b#561036bcc45f0a46a3ceef9f84a2161499243f03"
 dependencies = [
- "cidre-macros",
+ "cidre-macros 0.1.0 (git+https://github.com/yury/cidre.git?rev=561036b)",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "cidre"
+version = "0.7.0"
+source = "git+https://github.com/yury/cidre#e49c28f345324541268ab9bb1bfa31c5c5a9ec36"
+dependencies = [
+ "cidre-macros 0.1.0 (git+https://github.com/yury/cidre)",
  "parking_lot",
  "tokio",
 ]
@@ -707,6 +717,11 @@ dependencies = [
 name = "cidre-macros"
 version = "0.1.0"
 source = "git+https://github.com/yury/cidre.git?rev=561036b#561036bcc45f0a46a3ceef9f84a2161499243f03"
+
+[[package]]
+name = "cidre-macros"
+version = "0.1.0"
+source = "git+https://github.com/yury/cidre#e49c28f345324541268ab9bb1bfa31c5c5a9ec36"
 
 [[package]]
 name = "clang-sys"
@@ -1008,7 +1023,7 @@ version = "0.15.3"
 source = "git+https://github.com/domingasp/cpal.git#46b356b7a63dac86eb757c9d4173de3ccba19b28"
 dependencies = [
  "alsa",
- "cidre",
+ "cidre 0.7.0 (git+https://github.com/yury/cidre.git?rev=561036b)",
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
  "dasp_sample",
@@ -3563,6 +3578,7 @@ name = "orbit-cursor"
 version = "0.1.0"
 dependencies = [
  "border",
+ "cidre 0.7.0 (git+https://github.com/yury/cidre)",
  "cocoa 0.26.0",
  "cpal",
  "dispatch",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ features = ["default-formats"]
 tauri-plugin-macos-permissions = "2.2.0"
 cocoa = "0.26"
 objc = "0.2.7"
+cidre = { git = "https://github.com/yury/cidre" }
 
 [features]
 # for tauri-nspanel

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,8 @@
     "start_recording_dock",
     "request_permissions",
     "standalone_listbox",
-    "recording_input_options"
+    "recording_input_options",
+    "recording_source_selector"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -34,6 +34,9 @@ pub enum Events {
 
   #[strum(serialize = "closed_recording_input_options")]
   ClosedRecordingInputOptions,
+
+  #[strum(serialize = "collapsed_recording_source_selector")]
+  CollapsedRecordingSourceSelector,
 }
 
 #[derive(EnumString, AsRefStr, Display, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -49,14 +52,18 @@ pub enum WindowLabel {
 
   #[strum(serialize = "recording_input_options")]
   RecordingInputOptions,
+
+  #[strum(serialize = "recording_source_selector")]
+  RecordingSourceSelector,
 }
 
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PanelLevel {
   StartRecordingDock = 1,
-  RecordingInputOptions = 2,
-  StandaloneListBox = 3,
+  RecordingSourceSelector = 2,
+  RecordingInputOptions = 3,
+  StandaloneListBox = 4,
 }
 
 impl PanelLevel {

--- a/src-tauri/src/global_inputs/service.rs
+++ b/src-tauri/src/global_inputs/service.rs
@@ -6,7 +6,7 @@ use tauri::{Emitter, Manager};
 
 use crate::{
   constants::{Events, WindowLabel},
-  windows::service::is_coordinate_in_window,
+  windows::{commands::collapse_recording_source_selector, service::is_coordinate_in_window},
   APP_HANDLE,
 };
 
@@ -32,10 +32,19 @@ pub fn global_input_event_handler(event: Event) {
         .get_webview_window(WindowLabel::StandaloneListbox.as_ref())
         .unwrap();
 
+      let recording_source_selector = app_handle
+        .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
+        .unwrap();
+
       if !is_coordinate_in_window(pos.0, pos.1, &recording_input_options_window)
         && !is_coordinate_in_window(pos.0, pos.1, &standalone_listbox_window)
       {
         let _ = app_handle.emit(Events::RecordingInputOptionsDidResignKey.as_ref(), ());
+      }
+
+      if !is_coordinate_in_window(pos.0, pos.1, &recording_source_selector) {
+        collapse_recording_source_selector(app_handle.clone());
+        let _ = app_handle.emit(Events::CollapsedRecordingSourceSelector.as_ref(), ());
       }
     }
     _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,9 +34,10 @@ use tauri::{App, AppHandle, Manager, Wry};
 use tauri_plugin_store::{Store, StoreExt};
 use windows::{
   commands::{
-    hide_start_recording_dock, init_recording_input_options, init_standalone_listbox,
-    is_recording_input_options_open, is_start_recording_dock_open, quit_app,
-    show_recording_input_options, show_standalone_listbox, show_start_recording_dock,
+    collapse_recording_source_selector, expand_recording_source_selector,
+    hide_start_recording_dock, init_recording_input_options, init_recording_source_selector,
+    init_standalone_listbox, is_recording_input_options_open, is_start_recording_dock_open,
+    quit_app, show_recording_input_options, show_standalone_listbox, show_start_recording_dock,
   },
   service::{
     add_animation, add_border, convert_to_stationary_panel, handle_dock_positioning,
@@ -103,6 +104,9 @@ pub fn run() {
       init_recording_input_options,
       show_recording_input_options,
       hide_start_recording_dock,
+      init_recording_source_selector,
+      expand_recording_source_selector,
+      collapse_recording_source_selector,
       start_audio_listener,
       stop_audio_listener,
       list_audio_inputs,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod constants;
 mod global_inputs;
 #[cfg(target_os = "macos")]
 mod permissions;
+mod recording_sources;
 mod system_tray;
 mod windows;
 
@@ -28,6 +29,7 @@ use permissions::{
   service::{ensure_permissions, monitor_permissions},
 };
 use rdev::listen;
+use recording_sources::commands::list_monitors;
 use serde_json::{json, Value};
 use system_tray::service::create_system_tray;
 use tauri::{App, AppHandle, Manager, Wry};
@@ -114,7 +116,8 @@ pub fn run() {
       is_recording_input_options_open,
       list_cameras,
       start_camera_stream,
-      stop_camera_stream
+      stop_camera_stream,
+      list_monitors
     ])
     .manage(Mutex::new(AppState {
       start_recording_dock_opened: false,

--- a/src-tauri/src/recording_sources/commands.rs
+++ b/src-tauri/src/recording_sources/commands.rs
@@ -1,0 +1,31 @@
+use serde::Serialize;
+use tauri::{AppHandle, LogicalPosition, LogicalSize};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitorDetails {
+  pub id: String,
+  pub name: String,
+  pub position: LogicalPosition<f64>,
+  pub size: LogicalSize<f64>,
+}
+
+#[tauri::command]
+pub fn list_monitors(app_handle: AppHandle) -> Vec<MonitorDetails> {
+  let monitors = app_handle.available_monitors().unwrap();
+  let low_level_screens = cidre::ns::Screen::screens();
+
+  let mut monitor_details = Vec::new();
+  for i in 0..monitors.len() {
+    let scale_factor = monitors[i].scale_factor();
+
+    monitor_details.push(MonitorDetails {
+      id: monitors[i].name().unwrap().to_string(), // this is a unique identifier Monitor #xxxxx
+      name: low_level_screens[i].localized_name().to_string(),
+      position: monitors[i].position().to_logical(scale_factor),
+      size: monitors[i].size().to_logical(scale_factor),
+    });
+  }
+
+  monitor_details
+}

--- a/src-tauri/src/recording_sources/mod.rs
+++ b/src-tauri/src/recording_sources/mod.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -175,11 +175,6 @@ pub fn show_start_recording_dock(app_handle: &AppHandle, state: State<'_, Mutex<
     .unwrap();
   panel.order_front_regardless();
 
-  let recording_source_selector = app_handle
-    .get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
-    .unwrap();
-  recording_source_selector.order_front_regardless();
-
   // Showing/hiding doesn't remount component, instead we emit event to UI
   let _ = app_handle
     .emit(Events::StartRecordingDockOpened.as_ref(), ())
@@ -190,6 +185,12 @@ pub fn show_start_recording_dock(app_handle: &AppHandle, state: State<'_, Mutex<
         e
       )
     });
+
+  if let Ok(recording_source_selector) =
+    app_handle.get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
+  {
+    recording_source_selector.order_front_regardless();
+  }
 }
 
 #[tauri::command]

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -242,7 +242,7 @@ pub fn collapse_recording_source_selector(app_handle: AppHandle) {
     .unwrap();
 
   let size = LogicalSize {
-    width: 230.0,
+    width: 232.0,
     height: 40.0,
   };
   animate_resize(window, size, Some(Anchor::Bottom));

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -9,11 +9,13 @@ use crate::{
 };
 
 use super::service::{
-  add_border, add_close_panel_listener, convert_to_stationary_panel, position_window_above_dock,
+  add_animation, add_border, add_close_panel_listener, animate_resize, convert_to_stationary_panel,
+  position_window_above_dock, Anchor,
 };
 
 static INIT_STANDALONE_LISTBOX: Once = Once::new();
 static INIT_RECORDING_OPTIONS_PANEL: Once = Once::new();
+static INIT_RECORDING_SOURCE_SELECTOR: Once = Once::new();
 
 #[tauri::command]
 pub fn init_standalone_listbox(app_handle: AppHandle) {
@@ -68,6 +70,36 @@ pub fn init_recording_input_options(app_handle: AppHandle) {
         state.lock().unwrap().recording_input_options_opened = false;
       },
     );
+  });
+}
+
+#[tauri::command]
+pub fn init_recording_source_selector(app_handle: AppHandle) {
+  INIT_RECORDING_SOURCE_SELECTOR.call_once(|| {
+    let window = app_handle
+      .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
+      .unwrap();
+    add_border(&window);
+    add_animation(&window, 3);
+
+    let scale_factor = window.scale_factor().unwrap();
+    let dock = app_handle
+      .get_webview_window(WindowLabel::StartRecordingDock.as_ref())
+      .unwrap();
+
+    let dock_pos = dock
+      .outer_position()
+      .unwrap()
+      .to_logical::<f64>(scale_factor);
+    let dock_size = dock.outer_size().unwrap().to_logical::<f64>(scale_factor);
+
+    position_window_above_dock(
+      &app_handle,
+      WindowLabel::RecordingSourceSelector,
+      dock_pos.x + (dock_size.width / 2.0),
+    );
+
+    let _ = convert_to_stationary_panel(&window, PanelLevel::RecordingSourceSelector);
   });
 }
 
@@ -143,6 +175,11 @@ pub fn show_start_recording_dock(app_handle: &AppHandle, state: State<'_, Mutex<
     .unwrap();
   panel.order_front_regardless();
 
+  let recording_source_selector = app_handle
+    .get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
+    .unwrap();
+  recording_source_selector.order_front_regardless();
+
   // Showing/hiding doesn't remount component, instead we emit event to UI
   let _ = app_handle
     .emit(Events::StartRecordingDockOpened.as_ref(), ())
@@ -165,6 +202,12 @@ pub fn hide_start_recording_dock(app_handle: AppHandle, state: State<'_, Mutex<A
     .get_webview_panel(WindowLabel::StartRecordingDock.as_ref())
     .unwrap();
   panel.order_out(None);
+
+  let recording_source_selector = app_handle
+    .get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
+    .unwrap();
+  recording_source_selector.order_out(None);
+  collapse_recording_source_selector(app_handle);
 }
 
 #[tauri::command]
@@ -177,4 +220,30 @@ pub fn is_start_recording_dock_open(state: State<'_, Mutex<AppState>>) -> bool {
 pub fn is_recording_input_options_open(state: State<'_, Mutex<AppState>>) -> bool {
   let state = state.lock().unwrap();
   state.recording_input_options_opened
+}
+
+#[tauri::command]
+pub fn expand_recording_source_selector(app_handle: AppHandle) {
+  let window = app_handle
+    .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
+    .unwrap();
+
+  let size = LogicalSize {
+    width: 500.0,
+    height: 250.0,
+  };
+  animate_resize(window, size, Some(Anchor::Bottom));
+}
+
+#[tauri::command]
+pub fn collapse_recording_source_selector(app_handle: AppHandle) {
+  let window = app_handle
+    .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
+    .unwrap();
+
+  let size = LogicalSize {
+    width: 230.0,
+    height: 40.0,
+  };
+  animate_resize(window, size, Some(Anchor::Bottom));
 }

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::service::{
   add_animation, add_border, add_close_panel_listener, animate_resize, convert_to_stationary_panel,
-  position_window_above_dock, Anchor,
+  position_recording_source_selector, position_window_above_dock, Anchor,
 };
 
 static INIT_STANDALONE_LISTBOX: Once = Once::new();
@@ -82,22 +82,7 @@ pub fn init_recording_source_selector(app_handle: AppHandle) {
     add_border(&window);
     add_animation(&window, 3);
 
-    let scale_factor = window.scale_factor().unwrap();
-    let dock = app_handle
-      .get_webview_window(WindowLabel::StartRecordingDock.as_ref())
-      .unwrap();
-
-    let dock_pos = dock
-      .outer_position()
-      .unwrap()
-      .to_logical::<f64>(scale_factor);
-    let dock_size = dock.outer_size().unwrap().to_logical::<f64>(scale_factor);
-
-    position_window_above_dock(
-      &app_handle,
-      WindowLabel::RecordingSourceSelector,
-      dock_pos.x + (dock_size.width / 2.0),
-    );
+    position_recording_source_selector(&app_handle, &window);
 
     let _ = convert_to_stationary_panel(&window, PanelLevel::RecordingSourceSelector);
   });
@@ -189,6 +174,10 @@ pub fn show_start_recording_dock(app_handle: &AppHandle, state: State<'_, Mutex<
   if let Ok(recording_source_selector) =
     app_handle.get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
   {
+    let recording_source_selector_window = app_handle
+      .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
+      .unwrap();
+    position_recording_source_selector(app_handle, &recording_source_selector_window);
     recording_source_selector.order_front_regardless();
   }
 }

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, sync::Arc};
+use std::{ffi::CString, sync::Arc, time::Duration};
 
 use border::WebviewWindowExt as BorderWebviewWindowExt;
 use cocoa::{
@@ -9,7 +9,7 @@ use objc::{class, msg_send, sel, sel_impl};
 use tauri::{
   utils::config::WindowEffectsConfig,
   window::{Effect, EffectState},
-  AppHandle, Listener, LogicalPosition, Manager, WebviewWindow, WebviewWindowBuilder,
+  AppHandle, Listener, LogicalPosition, LogicalSize, Manager, WebviewWindow, WebviewWindowBuilder,
 };
 use tauri_nspanel::{
   block::ConcreteBlock,
@@ -233,6 +233,79 @@ pub fn is_coordinate_in_window(x: f64, y: f64, window: &WebviewWindow) -> bool {
   let right = left + (size.width as f64 / scale_factor);
 
   y >= top && y <= bottom && x >= left && x <= right
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone)]
+pub enum Anchor {
+  Bottom,
+  Left,
+  Top,
+  Right,
+}
+
+/// Resize window to target size with transition.
+///
+/// When no anchor provided sizing happens from top-left.
+pub fn animate_resize(
+  window: WebviewWindow,
+  target_width: f64,
+  target_height: f64,
+  anchor: Option<Anchor>,
+) {
+  std::thread::spawn(move || {
+    let steps = 60;
+    let delay = Duration::from_millis(175 / steps);
+
+    let start_size = window
+      .outer_size()
+      .unwrap()
+      .to_logical::<f64>(window.scale_factor().unwrap());
+
+    let start_position = window
+      .outer_position()
+      .unwrap()
+      .to_logical::<f64>(window.scale_factor().unwrap());
+
+    let start_x = start_position.x;
+    let start_y = start_position.y;
+    let start_width = start_size.width;
+    let start_height = start_size.height;
+
+    let delta_width = target_width - start_width;
+    let delta_height = target_height - start_height;
+
+    for i in 1..=steps {
+      let t = i as f64 / steps as f64;
+
+      let transition_width = start_width + delta_width * t;
+      let transition_height = start_height + delta_height * t;
+
+      let _ = window.set_size(LogicalSize::new(transition_width, transition_height));
+
+      if let Some(anchor) = anchor {
+        let (offset_x, offset_y) = match anchor {
+          Anchor::Bottom => (
+            (start_width - transition_width) / 2.0,
+            start_height - transition_height,
+          ),
+          Anchor::Left => (0.0, (start_height - transition_height) / 2.0),
+          Anchor::Top => ((start_width - transition_width) / 2.0, 0.0),
+          Anchor::Right => (
+            start_width - transition_width,
+            (start_height - transition_height) / 2.0,
+          ),
+        };
+
+        let new_x = start_x + offset_x;
+        let new_y = start_y + offset_y;
+
+        let _ = window.set_position(LogicalPosition::new(new_x, new_y));
+      }
+
+      std::thread::sleep(delay);
+    }
+  });
 }
 
 // endregion

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -159,6 +159,25 @@ pub fn handle_dock_positioning(window: &WebviewWindow) {
   }
 }
 
+pub fn position_recording_source_selector(app_handle: &AppHandle, window: &WebviewWindow) {
+  let scale_factor = window.scale_factor().unwrap();
+  let dock = app_handle
+    .get_webview_window(WindowLabel::StartRecordingDock.as_ref())
+    .unwrap();
+
+  let dock_pos = dock
+    .outer_position()
+    .unwrap()
+    .to_logical::<f64>(scale_factor);
+  let dock_size = dock.outer_size().unwrap().to_logical::<f64>(scale_factor);
+
+  position_window_above_dock(
+    app_handle,
+    WindowLabel::RecordingSourceSelector,
+    dock_pos.x + (dock_size.width / 2.0),
+  );
+}
+
 // endregion
 
 // region: Utilities

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -249,8 +249,7 @@ pub enum Anchor {
 /// When no anchor provided sizing happens from top-left.
 pub fn animate_resize(
   window: WebviewWindow,
-  target_width: f64,
-  target_height: f64,
+  target_size: LogicalSize<f64>,
   anchor: Option<Anchor>,
 ) {
   std::thread::spawn(move || {
@@ -272,8 +271,8 @@ pub fn animate_resize(
     let start_width = start_size.width;
     let start_height = start_size.height;
 
-    let delta_width = target_width - start_width;
-    let delta_height = target_height - start_height;
+    let delta_width = target_size.width - start_width;
+    let delta_height = target_size.height - start_height;
 
     for i in 1..=steps {
       let t = i as f64 / steps as f64;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
         "title": "Recording Source Selector",
         "label": "recording_source_selector",
         "url": "/recording-source-selector",
-        "width": 230,
+        "width": 232,
         "height": 40,
         "decorations": false,
         "resizable": false,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,6 +53,23 @@
           "radius": 10,
           "state": "active"
         }
+      },
+      {
+        "title": "Recording Source Selector",
+        "label": "recording_source_selector",
+        "url": "/recording-source-selector",
+        "width": 230,
+        "height": 40,
+        "decorations": false,
+        "resizable": false,
+        "shadow": true,
+        "transparent": true,
+        "visible": false,
+        "windowEffects": {
+          "effects": ["underWindowBackground"],
+          "radius": 10,
+          "state": "active"
+        }
       }
     ],
     "security": {

--- a/src/api/windows.ts
+++ b/src/api/windows.ts
@@ -11,6 +11,10 @@ export const initRecordingInputOptions = () => {
   void invoke(Commands.InitRecordingInputOptions);
 };
 
+export const InitRecordingSourceSelector = () => {
+  void invoke(Commands.InitRecordingSourceSelector);
+};
+
 export const hideStartRecordingDock = () => {
   void invoke(Commands.HideStartRecordingDock);
 };
@@ -38,4 +42,12 @@ export const showRecordingInputOptions = (x: number) => {
 
 export const isRecordingInputOptionsOpen = async (): Promise<boolean> => {
   return await invoke(Commands.IsRecordingInputOptionsOpen);
+};
+
+export const expandRecordingSourceSelector = () => {
+  void invoke(Commands.ExpandRecordingSourceSelector);
+};
+
+export const collapseRecordingSourceSelector = () => {
+  void invoke(Commands.CollapseRecordingSourceSelector);
 };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -3,6 +3,9 @@ import { useEffect, useState } from "react";
 
 import { checkPermissions } from "../api/permissions";
 import { Permissions, usePermissionsStore } from "../stores/permissions.store";
+import { rehydrateRecordingPreferencesStore } from "../stores/recording-preferences.store";
+import { updateStandaloneListBoxStore } from "../stores/standalone-listbox.store";
+import { rehydrateWindowReopenState } from "../stores/window-open-state.store";
 import { Events } from "../types/events";
 
 import { AppProvider } from "./provider";
@@ -28,6 +31,20 @@ export const App = () => {
 
     setUnlisten(() => unlistenFn);
   };
+
+  // Ensure stores are kept to date for all windows
+  const rehydrateStores = (e: StorageEvent) => {
+    updateStandaloneListBoxStore(e);
+    rehydrateRecordingPreferencesStore(e);
+    rehydrateWindowReopenState(e);
+  };
+
+  useEffect(() => {
+    window.addEventListener("storage", rehydrateStores);
+    return () => {
+      window.removeEventListener("storage", rehydrateStores);
+    };
+  }, []);
 
   useEffect(() => {
     void setupPermissions();

--- a/src/app/pages/listbox-standalone.tsx
+++ b/src/app/pages/listbox-standalone.tsx
@@ -1,5 +1,5 @@
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
-import { useEffect, useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { Selection } from "react-aria-components";
 import { useShallow } from "zustand/react/shallow";
 
@@ -7,7 +7,6 @@ import ListBox from "../../components/listbox/listbox";
 import ListBoxItem from "../../components/listbox-item/listbox-item";
 import {
   Item,
-  updateStandaloneListBoxStore,
   useStandaloneListBoxStore,
 } from "../../stores/standalone-listbox.store";
 
@@ -48,13 +47,6 @@ const StandaloneListBox = () => {
     const { width } = (await webview.innerSize()).toLogical(scaleFactor);
     await webview.setSize(new LogicalSize(width, finalHeight));
   };
-
-  useEffect(() => {
-    window.addEventListener("storage", updateStandaloneListBoxStore);
-    return () => {
-      window.removeEventListener("storage", updateStandaloneListBoxStore);
-    };
-  }, []);
 
   useLayoutEffect(() => {
     // Unbound webview height to allow proper calculation

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -1,0 +1,69 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  collapseRecordingSourceSelector,
+  expandRecordingSourceSelector,
+} from "../../api/windows";
+import Button from "../../components/button/button";
+import {
+  AppWindow,
+  rehydrateWindowReopenState,
+  useWindowReopenStore,
+} from "../../stores/window-open-state.store";
+import { Events } from "../../types/events";
+
+const RecordingSourceSelector = () => {
+  const startRecordingDockOpened = useWindowReopenStore(
+    useShallow((state) => state.windows[AppWindow.StartRecordingDock])
+  );
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const onToggle = () => {
+    // Invert the state
+    if (isExpanded) collapseRecordingSourceSelector();
+    else expandRecordingSourceSelector();
+    setIsExpanded((prev) => !prev);
+  };
+
+  useEffect(() => {
+    const unlisten = listen(Events.CollapsedRecordingSourceSelector, () => {
+      setIsExpanded(false);
+    });
+
+    return () => {
+      void unlisten.then((f) => {
+        f();
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [startRecordingDockOpened]);
+
+  useEffect(() => {
+    window.addEventListener("storage", rehydrateWindowReopenState);
+    return () => {
+      window.removeEventListener("storage", rehydrateWindowReopenState);
+    };
+  }, []);
+
+  return (
+    <div className="h-[100vh] flex flex-row p-2 gap-2 items-center justify-center">
+      <span className="text-xs text-muted font-semibold">Monitor:</span>
+      <Button
+        className="w-40 justify-center"
+        onPress={onToggle}
+        showFocus={false}
+        size="sm"
+      >
+        Built-In Display
+      </Button>
+    </div>
+  );
+};
+
+export default RecordingSourceSelector;

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -7,10 +7,8 @@ import {
   expandRecordingSourceSelector,
 } from "../../api/windows";
 import RecordingSource from "../../features/recording-source/components/recording-source";
-import { rehydrateRecordingPreferencesStore } from "../../stores/recording-preferences.store";
 import {
   AppWindow,
-  rehydrateWindowReopenState,
   useWindowReopenStore,
 } from "../../stores/window-open-state.store";
 import { Events } from "../../types/events";
@@ -21,11 +19,6 @@ const RecordingSourceSelector = () => {
   );
 
   const [isExpanded, setIsExpanded] = useState(false);
-
-  const rehydrateStores = (e: StorageEvent) => {
-    rehydrateWindowReopenState(e);
-    rehydrateRecordingPreferencesStore(e);
-  };
 
   const onToggle = () => {
     // Invert the state
@@ -49,13 +42,6 @@ const RecordingSourceSelector = () => {
   useEffect(() => {
     setIsExpanded(false);
   }, [startRecordingDockOpened]);
-
-  useEffect(() => {
-    window.addEventListener("storage", rehydrateStores);
-    return () => {
-      window.removeEventListener("storage", rehydrateStores);
-    };
-  }, []);
 
   return (
     <div className="flex flex-row p-2 h-[100vh] w-full items-end justify-center">

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -6,7 +6,8 @@ import {
   collapseRecordingSourceSelector,
   expandRecordingSourceSelector,
 } from "../../api/windows";
-import Button from "../../components/button/button";
+import RecordingSource from "../../features/recording-source/components/recording-source";
+import { rehydrateRecordingPreferencesStore } from "../../stores/recording-preferences.store";
 import {
   AppWindow,
   rehydrateWindowReopenState,
@@ -20,6 +21,11 @@ const RecordingSourceSelector = () => {
   );
 
   const [isExpanded, setIsExpanded] = useState(false);
+
+  const rehydrateStores = (e: StorageEvent) => {
+    rehydrateWindowReopenState(e);
+    rehydrateRecordingPreferencesStore(e);
+  };
 
   const onToggle = () => {
     // Invert the state
@@ -45,23 +51,15 @@ const RecordingSourceSelector = () => {
   }, [startRecordingDockOpened]);
 
   useEffect(() => {
-    window.addEventListener("storage", rehydrateWindowReopenState);
+    window.addEventListener("storage", rehydrateStores);
     return () => {
-      window.removeEventListener("storage", rehydrateWindowReopenState);
+      window.removeEventListener("storage", rehydrateStores);
     };
   }, []);
 
   return (
-    <div className="h-[100vh] flex flex-row p-2 gap-2 items-center justify-center">
-      <span className="text-xs text-muted font-semibold">Monitor:</span>
-      <Button
-        className="w-40 justify-center"
-        onPress={onToggle}
-        showFocus={false}
-        size="sm"
-      >
-        Built-In Display
-      </Button>
+    <div className="flex flex-row p-2 h-[100vh] w-full items-end justify-center">
+      <RecordingSource onPress={onToggle} />
     </div>
   );
 };

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider } from "react-router";
 
 import StandaloneListBox from "./pages/listbox-standalone";
 import RecordingInputOptions from "./pages/recording-input-options";
+import RecordingSourceSelector from "./pages/recording-source-selector";
 import RequestPermissions from "./pages/request-permissions/request-permissions";
 import StartRecordingDock from "./pages/start-recording-dock";
 
@@ -21,6 +22,10 @@ const router = createBrowserRouter([
   {
     element: <RecordingInputOptions />,
     path: "/recording-input-options",
+  },
+  {
+    element: <RecordingSourceSelector />,
+    path: "/recording-source-selector",
   },
 ]);
 

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -21,6 +21,10 @@ const colors: React.ComponentProps<typeof Button>["color"][] = [
 
 const meta = {
   argTypes: {
+    color: {
+      control: "inline-radio",
+      options: colors,
+    },
     size: {
       control: "inline-radio",
       options: sizes,

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -31,6 +31,11 @@ const buttonVariants = tv({
       color: "info",
       variant: "soft",
     },
+    {
+      class: "bg-neutral/75",
+      color: "neutral",
+      variant: "soft",
+    },
   ],
   defaultVariants: {
     color: "neutral",

--- a/src/components/content-rotate/content-rotate.stories.tsx
+++ b/src/components/content-rotate/content-rotate.stories.tsx
@@ -1,0 +1,64 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { IceCream } from "lucide-react";
+import { ReactNode } from "react";
+
+import Button from "../button/button";
+
+import ContentRotate from "./content-rotate";
+
+const childrenOptions: Record<string, ReactNode> = {
+  textOnly: "Chocolate",
+  withIcon: (
+    <>
+      <IceCream size={18} />
+      Vanilla
+    </>
+  ),
+};
+
+/** Styling is left to consumer */
+const meta = {
+  argTypes: {
+    contentKey: {
+      control: {
+        labels: {
+          textOnly: "Text Only",
+          withIcon: "With Icon",
+        },
+        type: "inline-radio",
+      },
+      options: Object.keys(childrenOptions),
+    },
+  },
+  args: {
+    children: childrenOptions.withIcon,
+    className: "text-content-fg flex gap-2 items-center",
+    contentKey: Object.keys(childrenOptions).at(0),
+  },
+  component: ContentRotate,
+  parameters: {
+    controls: { exclude: ["className", "children"] },
+    layout: "centered",
+  },
+  title: "Word Rotate",
+} satisfies Meta<typeof ContentRotate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: ({ children: _children, ...args }) => (
+    <ContentRotate {...args}>{childrenOptions[args.contentKey]}</ContentRotate>
+  ),
+};
+
+/** Recommendation is to set a defined width. */
+export const InButton: Story = {
+  render: ({ children: _children, ...args }) => (
+    <Button className="w-25 justify-center">
+      <ContentRotate {...args}>
+        {childrenOptions[args.contentKey]}
+      </ContentRotate>
+    </Button>
+  ),
+};

--- a/src/components/content-rotate/content-rotate.tsx
+++ b/src/components/content-rotate/content-rotate.tsx
@@ -1,0 +1,34 @@
+import { AnimatePresence, motion, MotionProps } from "motion/react";
+import { ReactNode } from "react";
+
+type ContentRotateProps = MotionProps & {
+  children: ReactNode;
+  contentKey: string;
+  className?: string;
+};
+const ContentRotate = ({
+  children,
+  className,
+  contentKey,
+  ...props
+}: ContentRotateProps) => {
+  return (
+    <div className="overflow-hidden">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={contentKey}
+          animate={{ opacity: 1, y: 0 }}
+          className={className}
+          exit={{ opacity: 0, y: 25 }}
+          initial={{ opacity: 0, y: -25 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          {...props}
+        >
+          {children}
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default ContentRotate;

--- a/src/components/overflow-shadow/overflow-shadow.stories.tsx
+++ b/src/components/overflow-shadow/overflow-shadow.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import OverflowShadow from "./overflow-shadow";
+
+/** Parent container must have `relative` and `overflow-hidden` applied. */
+const meta = {
+  argTypes: {
+    orientation: {
+      control: "inline-radio",
+      options: ["vertical", "horizontal"],
+      table: { readonly: true },
+    },
+  },
+  args: {
+    children: (
+      <>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </>
+    ),
+  },
+  component: OverflowShadow,
+  parameters: {
+    controls: { exclude: ["children"] },
+    layout: "centered",
+  },
+  title: "Overflow Shadow",
+} satisfies Meta<typeof OverflowShadow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
+  render: (args) => (
+    <div className="text-content-fg w-[150px] h-[100px] relative overflow-hidden">
+      <OverflowShadow {...args} />
+    </div>
+  ),
+};
+
+export const Horizontal: Story = {
+  args: {
+    orientation: "horizontal",
+  },
+  render: (args) => (
+    <div className="text-content-fg w-[150px] whitespace-nowrap relative overflow-hidden">
+      <OverflowShadow {...args} />
+    </div>
+  ),
+};

--- a/src/components/overflow-shadow/overflow-shadow.tsx
+++ b/src/components/overflow-shadow/overflow-shadow.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import { VariantProps } from "tailwind-variants";
+
+import { tv } from "../../../tailwind-merge.config";
+
+const overflowShadowVariants = tv({
+  compoundSlots: [
+    {
+      class: "absolute z-100 rounded-xs from-content-fg/25 to-transparent",
+      slots: ["end", "start"],
+    },
+    {
+      class: "w-full h-[10px]",
+      orientation: "vertical",
+      slots: ["end", "start"],
+    },
+    {
+      class: "w-[10px] h-full",
+      orientation: "horizontal",
+      slots: ["end", "start"],
+    },
+  ],
+  defaultVariants: {
+    orientation: "vertical",
+  },
+  slots: {
+    content: "overflow-scroll h-full p-2",
+    end: "",
+    start: "",
+  },
+  variants: {
+    orientation: {
+      horizontal: {
+        end: "right-0 bg-gradient-to-l",
+        start: "left-0 bg-gradient-to-r",
+      },
+      vertical: {
+        end: "bottom-0 bg-gradient-to-t",
+        start: "top-0 bg-gradient-to-b",
+      },
+    },
+  },
+});
+
+type OverflowShadowProps = VariantProps<typeof overflowShadowVariants> & {
+  children?: React.ReactNode;
+};
+const OverflowShadow = ({ children, orientation }: OverflowShadowProps) => {
+  const { content, end, start } = overflowShadowVariants({ orientation });
+  const startRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const [scrollTotal, setScrollTotal] = useState(0);
+
+  const onScroll = () => {
+    if (!contentRef.current || !startRef.current || !endRef.current) return;
+
+    const { scrollLeft, scrollTop } = contentRef.current;
+    const scrollAmount =
+      (orientation === "vertical" ? scrollTop : scrollLeft) / scrollTotal;
+
+    startRef.current.style.opacity = scrollAmount.toString();
+    endRef.current.style.opacity = (1 - scrollAmount).toString();
+  };
+
+  useEffect(() => {
+    if (contentRef.current && contentRef.current.parentElement) {
+      const { parentElement, scrollHeight, scrollWidth } = contentRef.current;
+      setScrollTotal(
+        (orientation === "vertical" ? scrollHeight : scrollWidth) -
+          parentElement.offsetWidth
+      );
+    }
+  }, [orientation]);
+
+  useEffect(() => {
+    if (scrollTotal > 0) {
+      contentRef.current?.addEventListener("scroll", onScroll);
+    }
+
+    return () => {
+      contentRef.current?.removeEventListener("scroll", onScroll);
+    };
+  }, [scrollTotal]);
+
+  return (
+    <>
+      <div ref={startRef} className={start()} style={{ opacity: "0" }} />
+      <div ref={endRef} className={end()} style={{ opacity: "1" }} />
+      <div ref={contentRef} className={content()}>
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default OverflowShadow;

--- a/src/features/camera-select/components/camera-select.tsx
+++ b/src/features/camera-select/components/camera-select.tsx
@@ -16,7 +16,6 @@ import {
   Item,
   selectedItem,
   StandaloneListBoxes,
-  updateStandaloneListBoxStore,
   useStandaloneListBoxStore,
 } from "../../../stores/standalone-listbox.store";
 import {
@@ -111,9 +110,7 @@ const CameraSelect = () => {
       }
     );
 
-    window.addEventListener("storage", updateStandaloneListBoxStore);
     return () => {
-      window.removeEventListener("storage", updateStandaloneListBoxStore);
       void unlistenStandaloneListBox.then((f) => {
         f();
       });

--- a/src/features/recording-controls/components/input-toggle-groups.tsx
+++ b/src/features/recording-controls/components/input-toggle-groups.tsx
@@ -14,12 +14,10 @@ import { useRecordingPreferencesStore } from "../../../stores/recording-preferen
 import {
   selectedItem,
   StandaloneListBoxes,
-  updateStandaloneListBoxStore,
   useStandaloneListBoxStore,
 } from "../../../stores/standalone-listbox.store";
 import {
   AppWindow,
-  rehydrateWindowReopenState,
   useWindowReopenStore,
 } from "../../../stores/window-open-state.store";
 import { listAudioInputs } from "../../audio-inputs/api/audio-listeners";
@@ -82,18 +80,6 @@ const InputToggleGroup = ({
       state.setSystemAudio,
     ])
   );
-
-  const rehydrateStores = (e: StorageEvent) => {
-    updateStandaloneListBoxStore(e);
-    rehydrateWindowReopenState(e);
-  };
-
-  useEffect(() => {
-    window.addEventListener("storage", rehydrateStores);
-    return () => {
-      window.removeEventListener("storage", rehydrateStores);
-    };
-  }, []);
 
   useEffect(() => {
     if (permissions.microphone?.hasAccess) {

--- a/src/features/recording-source/api/recording-sources.ts
+++ b/src/features/recording-source/api/recording-sources.ts
@@ -1,0 +1,16 @@
+import { invoke } from "@tauri-apps/api/core";
+import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
+
+import { Commands } from "../../../types/api";
+
+export type MonitorDetails = {
+  id: string;
+  name: string;
+  position: LogicalPosition;
+  size: LogicalSize;
+};
+
+export const listMonitors = async () => {
+  const monitors = await invoke(Commands.ListMonitors);
+  return monitors as MonitorDetails[];
+};

--- a/src/features/recording-source/components/monitor-selector.tsx
+++ b/src/features/recording-source/components/monitor-selector.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+
+import Button from "../../../components/button/button";
+import { listMonitors, MonitorDetails } from "../api/recording-sources";
+
+type MonitorSelectorProps = {
+  onSelect: (monitor: MonitorDetails) => void;
+  selectedMonitor: MonitorDetails | null;
+};
+const MonitorSelector = ({
+  onSelect,
+  selectedMonitor,
+}: MonitorSelectorProps) => {
+  const [monitors, setMonitors] = useState<MonitorDetails[]>([]);
+
+  const bounds = monitors.reduce(
+    (acc, { position: { x, y }, size: { height, width } }) => ({
+      maxX: Math.max(acc.maxX, x + width),
+      maxY: Math.max(acc.maxY, y + height),
+      minX: Math.min(acc.minX, x),
+      minY: Math.min(acc.minY, y),
+    }),
+    {
+      maxX: -Infinity,
+      maxY: -Infinity,
+      minX: Infinity,
+      minY: Infinity,
+    }
+  );
+
+  const layoutWidth = bounds.maxX - bounds.minX;
+  const layoutHeight = bounds.maxY - bounds.minY;
+  const aspectRatio = layoutWidth / layoutHeight;
+
+  useEffect(() => {
+    void listMonitors().then((monitors) => {
+      setMonitors(monitors);
+    });
+  }, []);
+
+  return (
+    <div className="flex justify-center items-center w-full h-full inset-shadow-full rounded-md relative overflow-hidden">
+      <div
+        className="relative"
+        style={{
+          aspectRatio,
+          // Calculate width/height due to aspect ratio and absolute child
+          height: `min(80%, 80vw / (${aspectRatio.toString()}))`,
+          width: `min(80%, 80vh * (${aspectRatio.toString()}))`,
+        }}
+      >
+        <div className="absolute inset-0">
+          {monitors.map((monitor) => {
+            const { id, name, position, size } = monitor;
+            const left = ((position.x - bounds.minX) / layoutWidth) * 100;
+            const top = ((position.y - bounds.minY) / layoutHeight) * 100;
+            const width = (size.width / layoutWidth) * 100;
+            const height = (size.height / layoutHeight) * 100;
+
+            return (
+              <Button
+                key={id}
+                className="absolute justify-center shadow-md text-xxs"
+                variant="soft"
+                color={
+                  selectedMonitor && selectedMonitor.id === id
+                    ? "info"
+                    : "neutral"
+                }
+                onPress={() => {
+                  onSelect(monitor);
+                }}
+                style={{
+                  height: `${height.toString()}%`,
+                  left: `${left.toString()}%`,
+                  top: `${top.toString()}%`,
+                  width: `${width.toString()}%`,
+                }}
+              >
+                <span className="truncate w-full">{name}</span>
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MonitorSelector;

--- a/src/features/recording-source/components/recording-source.tsx
+++ b/src/features/recording-source/components/recording-source.tsx
@@ -1,5 +1,4 @@
 import { AppWindowMac, Monitor } from "lucide-react";
-import { useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import Button from "../../../components/button/button";
@@ -8,32 +7,14 @@ import {
   RecordingType,
   useRecordingPreferencesStore,
 } from "../../../stores/recording-preferences.store";
-import { listMonitors } from "../api/recording-sources";
 
 type RecordingSourceProps = {
   onPress: () => void;
 };
 const RecordingSource = ({ onPress }: RecordingSourceProps) => {
-  const [recordingType, selectedMonitor, setSelectedMonitor] =
-    useRecordingPreferencesStore(
-      useShallow((state) => [
-        state.recordingType,
-        state.selectedMonitor,
-        state.setSelectedMonitor,
-      ])
-    );
-
-  useEffect(() => {
-    void listMonitors().then((monitors) => {
-      if (
-        !selectedMonitor ||
-        (monitors.find((monitor) => monitor.id === selectedMonitor.id) &&
-          monitors.length > 0)
-      ) {
-        setSelectedMonitor(monitors[0]);
-      }
-    });
-  }, []);
+  const [recordingType, selectedMonitor] = useRecordingPreferencesStore(
+    useShallow((state) => [state.recordingType, state.selectedMonitor])
+  );
 
   return (
     <div className="flex flex-row gap-2 items-center justify-center">

--- a/src/features/recording-source/components/recording-source.tsx
+++ b/src/features/recording-source/components/recording-source.tsx
@@ -1,0 +1,76 @@
+import { AppWindowMac, Monitor } from "lucide-react";
+import { useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import Button from "../../../components/button/button";
+import ContentRotate from "../../../components/content-rotate/content-rotate";
+import {
+  RecordingType,
+  useRecordingPreferencesStore,
+} from "../../../stores/recording-preferences.store";
+import { listMonitors } from "../api/recording-sources";
+
+type RecordingSourceProps = {
+  onPress: () => void;
+};
+const RecordingSource = ({ onPress }: RecordingSourceProps) => {
+  const [recordingType, selectedMonitor, setSelectedMonitor] =
+    useRecordingPreferencesStore(
+      useShallow((state) => [
+        state.recordingType,
+        state.selectedMonitor,
+        state.setSelectedMonitor,
+      ])
+    );
+
+  useEffect(() => {
+    void listMonitors().then((monitors) => {
+      if (
+        !selectedMonitor ||
+        (monitors.find((monitor) => monitor.id === selectedMonitor.id) &&
+          monitors.length > 0)
+      ) {
+        setSelectedMonitor(monitors[0]);
+      }
+    });
+  }, []);
+
+  return (
+    <div className="flex flex-row gap-2 items-center justify-center">
+      <ContentRotate
+        className=" flex gap-2 items-center text-xxs justify-center text-muted font-semibold w-16"
+        contentKey={
+          recordingType === RecordingType.Window ? "window" : "monitor"
+        }
+      >
+        {recordingType === RecordingType.Window ? (
+          <>
+            <AppWindowMac size={12} />
+            Window
+          </>
+        ) : (
+          <>
+            <Monitor size={12} />
+            Monitor
+          </>
+        )}
+      </ContentRotate>
+
+      <Button
+        className="w-36 justify-center"
+        onPress={onPress}
+        showFocus={false}
+        size="sm"
+      >
+        <ContentRotate
+          className="truncate"
+          contentKey={selectedMonitor?.id ?? ""}
+        >
+          {selectedMonitor?.name ?? "None"}
+        </ContentRotate>
+      </Button>
+    </div>
+  );
+};
+
+export default RecordingSource;

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,8 @@
   --blur-md: 4px;
   --blur-lg: 5px;
 
+  --inset-shadow-full: inset 0 0 8px rgb(0 0 0/0.25);
+
   /* ----------------------------- Theme Dependent ---------------------------- */
   --color-content: white;
   --color-content-fg: var(--color-neutral-800);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 
 import {
   initRecordingInputOptions,
+  InitRecordingSourceSelector,
   initStandaloneListBox,
 } from "./api/windows";
 import { App } from "./app";
@@ -10,6 +11,7 @@ import "./index.css";
 
 initStandaloneListBox();
 initRecordingInputOptions();
+InitRecordingSourceSelector();
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/stores/recording-preferences.store.ts
+++ b/src/stores/recording-preferences.store.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
+import { MonitorDetails } from "../features/recording-source/api/recording-sources";
+
 const STORE_NAME = "recordingPreferences";
 
 export enum RecordingType {
@@ -13,9 +15,11 @@ type RecordingPreferencesState = {
   camera: boolean;
   microphone: boolean;
   recordingType: RecordingType;
+  selectedMonitor: MonitorDetails | null;
   setCamera: (camera: boolean) => void;
   setMicrophone: (microphone: boolean) => void;
   setRecordingType: (recordingType: RecordingType) => void;
+  setSelectedMonitor: (selectedMonitor: MonitorDetails) => void;
   setSystemAudio: (systemAudio: boolean) => void;
   systemAudio: boolean;
 };
@@ -27,6 +31,7 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
         camera: false,
         microphone: false,
         recordingType: RecordingType.Region,
+        selectedMonitor: null,
         setCamera: (camera) => {
           set({ camera });
         },
@@ -35,6 +40,9 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
         },
         setRecordingType: (recordingType) => {
           set({ recordingType });
+        },
+        setSelectedMonitor: (selectedMonitor) => {
+          set({ selectedMonitor });
         },
         setSystemAudio: (systemAudio) => {
           set({ systemAudio });
@@ -45,3 +53,10 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
     )
   )
 );
+
+export const rehydrateRecordingPreferencesStore = (e: StorageEvent) => {
+  const { key } = e;
+  if (key === STORE_NAME) {
+    void useRecordingPreferencesStore.persist.rehydrate();
+  }
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -19,4 +19,5 @@ export enum Commands {
   StopCameraStream = "stop_camera_stream",
   ExpandRecordingSourceSelector = "expand_recording_source_selector",
   CollapseRecordingSourceSelector = "collapse_recording_source_selector",
+  ListMonitors = "list_monitors",
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,6 +1,7 @@
 export enum Commands {
   InitStandaloneListBox = "init_standalone_listbox",
   InitRecordingInputOptions = "init_recording_input_options",
+  InitRecordingSourceSelector = "init_recording_source_selector",
   CheckPermissions = "check_permissions",
   RequestPermission = "request_permission",
   OpenSystemSettings = "open_system_settings",
@@ -16,4 +17,6 @@ export enum Commands {
   ListCameras = "list_cameras",
   StartCameraStream = "start_camera_stream",
   StopCameraStream = "stop_camera_stream",
+  ExpandRecordingSourceSelector = "expand_recording_source_selector",
+  CollapseRecordingSourceSelector = "collapse_recording_source_selector",
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -6,4 +6,5 @@ export enum Events {
   ClosedRecordingInputOptions = "closed_recording_input_options",
   SystemAudioStreamError = "system_audio_stream_error",
   InputAudioStreamError = "input_audio_stream_error",
+  CollapsedRecordingSourceSelector = "collapsed_recording_source_selector",
 }


### PR DESCRIPTION
Arrangement of monitors makes it clear to the user which monitor is which, monitor names can be confusing.

For the expanding/collapsing I've opted for custom interpolation. This does create a choppy animation due to the position constantly shifting to maintain the panel in the centre but there's no way I could find to smooth it. By default the anchor point is top-left in Tauri.

This also sets the foundation for listing the available windows in the future.

https://github.com/user-attachments/assets/b7ad987c-bac1-4695-824a-b77a547369ae

