### PR TITLE
Add recording in progress dock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -733,8 +733,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -3999,6 +4001,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "border",
+ "chrono",
  "cidre 0.7.0 (git+https://github.com/yury/cidre)",
  "cocoa 0.26.0",
  "cpal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ base64 = "0.22.1"
 futures = "0.3.31"
 xcap = "0.6.0"
 uuid = { version = "1.17.0", features = ["v4"] }
+chrono = "0.4.41"
 
 [dependencies.nokhwa]
 git = "https://github.com/l1npengtul/nokhwa.git"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,18 +2,12 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for windows",
-  "windows": [
-    "start_recording_dock",
-    "request_permissions",
-    "standalone_listbox",
-    "recording_input_options",
-    "region_selector",
-    "recording_source_selector"
-  ],
+  "windows": ["*"],
   "permissions": [
     "core:default",
     "opener:default",
     "core:window:allow-set-size",
+    "core:window:allow-start-dragging",
     "macos-permissions:default",
     {
       "identifier": "shell:allow-execute",

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -58,6 +58,9 @@ pub enum WindowLabel {
 
   #[strum(serialize = "recording_source_selector")]
   RecordingSourceSelector,
+
+  #[strum(serialize = "recording_dock")]
+  RecordingDock,
 }
 
 #[repr(i32)]
@@ -68,6 +71,7 @@ pub enum PanelLevel {
   RecordingSourceSelector = 3,
   RecordingInputOptions = 4,
   StandaloneListBox = 5,
+  RecordingDock = 6,
 }
 
 impl PanelLevel {

--- a/src-tauri/src/recording_state/commands.rs
+++ b/src-tauri/src/recording_state/commands.rs
@@ -1,0 +1,33 @@
+use std::sync::Mutex;
+
+use chrono::Local;
+use tauri::{AppHandle, State};
+use tauri_nspanel::ManagerExt;
+
+use crate::{constants::WindowLabel, AppState};
+
+#[tauri::command]
+pub fn start_recording(app_handle: AppHandle, state: State<'_, Mutex<AppState>>) {
+  if let Ok(mut state) = state.lock() {
+    state.is_recording = true;
+  }
+
+  let recording_dock = app_handle
+    .get_webview_panel(WindowLabel::RecordingDock.as_ref())
+    .unwrap();
+  recording_dock.order_front_regardless();
+}
+
+#[tauri::command]
+pub fn stop_recording(app_handle: AppHandle, state: State<'_, Mutex<AppState>>) {
+  if let Ok(mut state) = state.lock() {
+    state.is_recording = false;
+  }
+
+  println!("Stopped at: {}", Local::now().format("%Y-%m-%d %H:%M:%S"));
+
+  let recording_dock = app_handle
+    .get_webview_panel(WindowLabel::RecordingDock.as_ref())
+    .unwrap();
+  recording_dock.order_out(None);
+}

--- a/src-tauri/src/recording_state/mod.rs
+++ b/src-tauri/src/recording_state/mod.rs
@@ -1,0 +1,1 @@
+pub mod commands;

--- a/src-tauri/src/screen_capture/commands.rs
+++ b/src-tauri/src/screen_capture/commands.rs
@@ -4,15 +4,19 @@ use std::{
 };
 
 use scap::frame::Frame;
-use tauri::{ipc::Channel, Manager, State};
+use tauri::{ipc::Channel, AppHandle, Manager, State};
 
 use crate::{AppState, APP_HANDLE};
 
 use super::service::{self, bgra_frame_to_rgba_buffer};
 
 #[tauri::command]
-pub fn init_magnifier_capturer(state: State<'_, Mutex<AppState>>, display_name: String) {
-  service::init_magnifier_capturer(state, display_name);
+pub fn init_magnifier_capturer(
+  app_handle: AppHandle,
+  state: State<'_, Mutex<AppState>>,
+  display_name: String,
+) {
+  service::init_magnifier_capturer(app_handle, state, display_name);
 }
 
 #[tauri::command]

--- a/src-tauri/src/screen_capture/service.rs
+++ b/src-tauri/src/screen_capture/service.rs
@@ -5,13 +5,17 @@ use scap::{
   frame::BGRAFrame,
   get_all_targets, Target,
 };
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 use yuv::bgra_to_rgba;
 
 use crate::AppState;
 
-pub fn init_magnifier_capturer(state: State<'_, Mutex<AppState>>, display_name: String) {
-  let targets_to_exclude = get_app_targets();
+pub fn init_magnifier_capturer(
+  app_handle: AppHandle,
+  state: State<'_, Mutex<AppState>>,
+  display_name: String,
+) {
+  let targets_to_exclude = get_app_targets(app_handle);
   let display = get_display(display_name);
 
   let options = Options {
@@ -33,16 +37,14 @@ pub fn init_magnifier_capturer(state: State<'_, Mutex<AppState>>, display_name: 
 }
 
 /// Return targets which are part of the app
-fn get_app_targets() -> Vec<Target> {
+fn get_app_targets(app_handle: AppHandle) -> Vec<Target> {
   let targets = get_all_targets();
 
-  let app_window_titles_to_exclude = [
-    "Start Recording Dock",
-    "Recording Source Selector",
-    "Region Selector",
-    "Standalone ListBox",
-    "Recording Input Options",
-  ];
+  let app_window_titles_to_exclude: Vec<String> = app_handle
+    .webview_windows()
+    .iter()
+    .map(|w| w.1.title().unwrap())
+    .collect();
 
   targets
     .into_iter()

--- a/src-tauri/src/system_tray/service.rs
+++ b/src-tauri/src/system_tray/service.rs
@@ -1,13 +1,13 @@
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
-use tauri::{App, Manager};
+use tauri::{AppHandle, Manager};
 
 use crate::windows::commands::show_start_recording_dock;
 
-pub fn create_system_tray(app: &App) -> tauri::Result<()> {
-  let quit_i = MenuItem::with_id(app, "quit", "Quit Orbit Cursor", true, None::<&str>)?;
-  let menu = Menu::with_items(app, &[&quit_i])?;
-  let tray = app.tray_by_id("tray_icon").unwrap();
+pub fn init_system_tray(app_handle: AppHandle) -> tauri::Result<()> {
+  let quit_i = MenuItem::with_id(&app_handle, "quit", "Quit Orbit Cursor", true, None::<&str>)?;
+  let menu = Menu::with_items(&app_handle, &[&quit_i])?;
+  let tray = app_handle.tray_by_id("tray_icon").unwrap();
   tray.on_menu_event(|app, event| match event.id.as_ref() {
     "quit" => {
       app.exit(0);

--- a/src-tauri/src/windows/service.rs
+++ b/src-tauri/src/windows/service.rs
@@ -174,6 +174,20 @@ pub fn position_recording_source_selector(app_handle: &AppHandle, window: &Webvi
   );
 }
 
+pub fn position_recording_dock(window: &WebviewWindow) {
+  if let Ok(Some(monitor)) = window.current_monitor() {
+    let scale_factor = monitor.scale_factor();
+    let window_size = window.outer_size().unwrap().to_logical::<f64>(scale_factor);
+    let monitor_size = monitor.size().to_logical::<f64>(scale_factor);
+
+    let margin = 10.0;
+    let x = monitor_size.width / 2.0 - window_size.width / 2.0;
+    let y = window_size.height + margin;
+
+    let _ = window.set_position(LogicalPosition { x, y });
+  }
+}
+
 // endregion
 
 // region: Utilities

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,6 +81,23 @@
           "radius": 10,
           "state": "active"
         }
+      },
+      {
+        "title": "Recording Dock",
+        "label": "recording_dock",
+        "url": "/recording-dock",
+        "width": 130,
+        "height": 40,
+        "decorations": false,
+        "resizable": false,
+        "shadow": true,
+        "transparent": true,
+        "visible": false,
+        "windowEffects": {
+          "effects": ["underWindowBackground"],
+          "radius": 10,
+          "state": "active"
+        }
       }
     ],
     "security": {

--- a/src/api/windows.ts
+++ b/src/api/windows.ts
@@ -19,6 +19,10 @@ export const initRegionSelector = () => {
   void invoke(Commands.InitRegionSelector);
 };
 
+export const initRecordingDock = () => {
+  void invoke(Commands.InitRecordingDock);
+};
+
 export const hideStartRecordingDock = () => {
   void invoke(Commands.HideStartRecordingDock);
 };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 import { checkPermissions } from "../api/permissions";
 import { Permissions, usePermissionsStore } from "../stores/permissions.store";
-import { rehydrateRecordingPreferencesStore } from "../stores/recording-preferences.store";
+import { rehydrateRecordingStateStore } from "../stores/recording-state.store";
 import { updateStandaloneListBoxStore } from "../stores/standalone-listbox.store";
 import { rehydrateWindowReopenState } from "../stores/window-open-state.store";
 import { Events } from "../types/events";
@@ -35,7 +35,7 @@ export const App = () => {
   // Ensure stores are kept to date for all windows
   const rehydrateStores = (e: StorageEvent) => {
     updateStandaloneListBoxStore(e);
-    rehydrateRecordingPreferencesStore(e);
+    rehydrateRecordingStateStore(e);
     rehydrateWindowReopenState(e);
   };
 

--- a/src/app/pages/recording-dock.tsx
+++ b/src/app/pages/recording-dock.tsx
@@ -1,0 +1,39 @@
+import { CircleStop, GripVertical } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+
+import Button from "../../components/button/button";
+import ElapsedTime from "../../features/elapsed-time/components/elapsed-time";
+import { stopRecording } from "../../features/recording-controls/api/recording-state";
+import { useRecordingStateStore } from "../../stores/recording-state.store";
+
+const RecordingDock = () => {
+  const isRecording = useRecordingStateStore(
+    useShallow((state) => state.isRecording)
+  );
+
+  return (
+    <div className="flex flex-row w-screen h-screen justify-center">
+      <div
+        className="w-full h-full text-muted cursor-grab flex justify-center items-center"
+        data-tauri-drag-region
+      >
+        <GripVertical className="ml-[2px] pointer-events-none" size={20} />
+      </div>
+
+      <Button
+        className="px-2 select-none my-1 mr-1"
+        color="neutral"
+        showFocus={false}
+        variant="soft"
+        onPress={() => {
+          stopRecording();
+        }}
+      >
+        <CircleStop className="animate-pulse" size={18} />
+        {isRecording && <ElapsedTime />}
+      </Button>
+    </div>
+  );
+};
+
+export default RecordingDock;

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -20,8 +20,8 @@ import SelectorWrapper from "../../features/recording-source/components/selector
 import WindowSelector from "../../features/recording-source/components/window-selector";
 import {
   RecordingType,
-  useRecordingPreferencesStore,
-} from "../../stores/recording-preferences.store";
+  useRecordingStateStore,
+} from "../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -38,7 +38,7 @@ const RecordingSourceSelector = () => {
     selectedWindow,
     setSelectedWindow,
     recordingType,
-  ] = useRecordingPreferencesStore(
+  ] = useRecordingStateStore(
     useShallow((state) => [
       state.selectedMonitor,
       state.setSelectedMonitor,

--- a/src/app/pages/start-recording-dock.tsx
+++ b/src/app/pages/start-recording-dock.tsx
@@ -8,6 +8,7 @@ import { isStartRecordingDockOpen } from "../../api/windows";
 import Overlay from "../../components/overlay/overlay";
 import RecordingControls from "../../features/recording-controls/components/recording-controls";
 import { usePermissionsStore } from "../../stores/permissions.store";
+import { useRecordingStateStore } from "../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -23,6 +24,10 @@ const StartRecordingDock = () => {
     useShallow((state) => [state.addWindow, state.setWindowOpenState])
   );
 
+  const setIsRecording = useRecordingStateStore(
+    useShallow((state) => state.setIsRecording)
+  );
+
   const noPermissions =
     !accessibility?.hasAccess || !screen?.hasAccess || !canUnlock;
 
@@ -34,6 +39,7 @@ const StartRecordingDock = () => {
 
     const unlisten = listen(Events.StartRecordingDockOpened, () => {
       setWindowOpenState(AppWindow.StartRecordingDock, true);
+      setIsRecording(false);
     });
 
     return () => {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router";
 
 import StandaloneListBox from "./pages/listbox-standalone";
+import RecordingDock from "./pages/recording-dock";
 import RecordingInputOptions from "./pages/recording-input-options";
 import RecordingSourceSelector from "./pages/recording-source-selector";
 import Region from "./pages/region";
@@ -31,6 +32,10 @@ const router = createBrowserRouter([
   {
     element: <RecordingSourceSelector />,
     path: "/recording-source-selector",
+  },
+  {
+    element: <RecordingDock />,
+    path: "/recording-dock",
   },
 ]);
 

--- a/src/features/audio-inputs/components/archive/system-audio-toggle.tsx
+++ b/src/features/audio-inputs/components/archive/system-audio-toggle.tsx
@@ -6,7 +6,7 @@ import { useShallow } from "zustand/react/shallow";
 
 import Switch from "../../../../components/switch/switch";
 import { cn } from "../../../../lib/styling";
-import { useRecordingPreferencesStore } from "../../../../stores/recording-preferences.store";
+import { useRecordingStateStore } from "../../../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -27,7 +27,7 @@ const SystemAudioToggle = () => {
     useShallow((state) => state.windows[AppWindow.StartRecordingDock])
   );
 
-  const [systemAudio, setSystemAudio] = useRecordingPreferencesStore(
+  const [systemAudio, setSystemAudio] = useRecordingStateStore(
     useShallow((state) => [state.systemAudio, state.setSystemAudio])
   );
 

--- a/src/features/elapsed-time/components/elapsed-time.tsx
+++ b/src/features/elapsed-time/components/elapsed-time.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useMemo, useState } from "react";
+
+import NumberRotate from "./number-rotate";
+
+const ElapsedTime = () => {
+  const [secondsElapsed, setSecondsElapsed] = useState(0);
+
+  const formatTime = (seconds: number) => {
+    const hrs = String(Math.floor(seconds / 3600)).padStart(2, "0");
+    const mins = String(Math.floor((seconds % 3600) / 60)).padStart(2, "0");
+    const secs = String(seconds % 60).padStart(2, "0");
+
+    return { hrs, mins, secs };
+  };
+
+  const time = useMemo(() => formatTime(secondsElapsed), [secondsElapsed]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setSecondsElapsed((prev) => prev + 1);
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-row items-center text-xs font-semibold w-14 tabular-nums">
+      <NumberRotate>{time.hrs}</NumberRotate>:
+      <NumberRotate>{time.mins}</NumberRotate>:{time.secs}
+    </div>
+  );
+};
+
+export default ElapsedTime;

--- a/src/features/elapsed-time/components/number-rotate.tsx
+++ b/src/features/elapsed-time/components/number-rotate.tsx
@@ -1,0 +1,16 @@
+import ContentRotate from "../../../components/content-rotate/content-rotate";
+
+type NumberRotateProps = {
+  children: string;
+};
+const NumberRotate = ({ children }: NumberRotateProps) => {
+  const values = children.split("");
+
+  return values.map((v, i) => (
+    <ContentRotate key={i} contentKey={v}>
+      {v}
+    </ContentRotate>
+  ));
+};
+
+export default NumberRotate;

--- a/src/features/recording-controls/api/recording-state.ts
+++ b/src/features/recording-controls/api/recording-state.ts
@@ -1,0 +1,11 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { Commands } from "../../../types/api";
+
+export const startRecording = () => {
+  void invoke(Commands.StartRecording);
+};
+
+export const stopRecording = () => {
+  void invoke(Commands.StopRecording);
+};

--- a/src/features/recording-controls/components/input-toggle-groups.tsx
+++ b/src/features/recording-controls/components/input-toggle-groups.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import { usePermissionsStore } from "../../../stores/permissions.store";
-import { useRecordingPreferencesStore } from "../../../stores/recording-preferences.store";
+import { useRecordingStateStore } from "../../../stores/recording-state.store";
 import {
   selectedItem,
   StandaloneListBoxes,
@@ -70,7 +70,7 @@ const InputToggleGroup = ({
     setMicrophone,
     systemAudio,
     setSystemAudio,
-  ] = useRecordingPreferencesStore(
+  ] = useRecordingStateStore(
     useShallow((state) => [
       state.camera,
       state.setCamera,

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -12,10 +12,12 @@ import Keyboard from "../../../components/keyboard/keyboard";
 import Separator from "../../../components/separator/separator";
 import Sparkles from "../../../components/sparkles/sparkles";
 import { clearInteractionAttributes } from "../../../lib/styling";
+import { useRecordingStateStore } from "../../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
 } from "../../../stores/window-open-state.store";
+import { startRecording } from "../api/recording-state";
 
 import InputToggleGroup from "./input-toggle-groups";
 import RecordingTypeRadioGroup from "./recording-type-radio-group";
@@ -29,6 +31,10 @@ const RecordingControls = () => {
   const optionsButtonRef = useRef<HTMLButtonElement>(null);
   const setWindowOpenState = useWindowReopenStore(
     useShallow((state) => state.setWindowOpenState)
+  );
+
+  const setIsRecording = useRecordingStateStore(
+    useShallow((state) => state.setIsRecording)
   );
 
   const onCancel = () => {
@@ -48,6 +54,12 @@ const RecordingControls = () => {
 
     // Position at center x of options button,
     showRecordingInputOptions(x + (left + width / 2));
+  };
+
+  const onStartRecording = () => {
+    onCancel(); // Closes dock
+    startRecording();
+    setIsRecording(true);
   };
 
   return (
@@ -99,6 +111,9 @@ const RecordingControls = () => {
           className="self-stretch cursor-default group"
           showFocus={false}
           variant="ghost"
+          onPress={() => {
+            onStartRecording();
+          }}
         >
           <div className="flex flex-col gap-1 items-center">
             <Circle

--- a/src/features/recording-controls/components/recording-type-radio-group.tsx
+++ b/src/features/recording-controls/components/recording-type-radio-group.tsx
@@ -7,8 +7,8 @@ import Keyboard from "../../../components/keyboard/keyboard";
 import RadioGroup from "../../../components/radio-group/radio-group";
 import {
   RecordingType,
-  useRecordingPreferencesStore,
-} from "../../../stores/recording-preferences.store";
+  useRecordingStateStore,
+} from "../../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -27,7 +27,7 @@ const RecordingTypeRadioGroup = () => {
   );
 
   const [recordingType, setRecordingType, selectedMonitor] =
-    useRecordingPreferencesStore(
+    useRecordingStateStore(
       useShallow((state) => [
         state.recordingType,
         state.setRecordingType,

--- a/src/features/recording-source/components/recording-source.tsx
+++ b/src/features/recording-source/components/recording-source.tsx
@@ -7,15 +7,15 @@ import Button from "../../../components/button/button";
 import ContentRotate from "../../../components/content-rotate/content-rotate";
 import {
   RecordingType,
-  useRecordingPreferencesStore,
-} from "../../../stores/recording-preferences.store";
+  useRecordingStateStore,
+} from "../../../stores/recording-state.store";
 
 type RecordingSourceProps = {
   onPress: () => void;
 };
 const RecordingSource = ({ onPress }: RecordingSourceProps) => {
   const [recordingType, selectedMonitor, selectedWindow] =
-    useRecordingPreferencesStore(
+    useRecordingStateStore(
       useShallow((state) => [
         state.recordingType,
         state.selectedMonitor,

--- a/src/features/region-selector/components/magnifier/magnifier.tsx
+++ b/src/features/region-selector/components/magnifier/magnifier.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { RefObject, useEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
-import { useRecordingPreferencesStore } from "../../../../stores/recording-preferences.store";
+import { useRecordingStateStore } from "../../../../stores/recording-state.store";
 import {
   initMagnifierCapturer,
   startMagnifierCapture,
@@ -25,7 +25,7 @@ const Magnifier = ({
   resizeDirection,
   zoomFactor = 5,
 }: MagnifierProps) => {
-  const selectedMonitor = useRecordingPreferencesStore(
+  const selectedMonitor = useRecordingStateStore(
     useShallow((state) => state.selectedMonitor)
   );
 

--- a/src/features/region-selector/components/region-selector.tsx
+++ b/src/features/region-selector/components/region-selector.tsx
@@ -14,9 +14,9 @@ import {
 } from "../../../api/windows";
 import { cn } from "../../../lib/styling";
 import {
-  useRecordingPreferencesStore,
+  useRecordingStateStore,
   RecordingType,
-} from "../../../stores/recording-preferences.store";
+} from "../../../stores/recording-state.store";
 import {
   AppWindow,
   useWindowReopenStore,
@@ -97,7 +97,7 @@ const RegionSelector = () => {
     useShallow((state) => state.windows[AppWindow.StartRecordingDock])
   );
   const [region, setRegion, recordingType, selectedMonitor] =
-    useRecordingPreferencesStore(
+    useRecordingStateStore(
       useShallow((state) => [
         state.region,
         state.setRegion,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import {
   initRegionSelector,
   initRecordingSourceSelector,
   initStandaloneListBox,
+  initRecordingDock,
 } from "./api/windows";
 import { App } from "./app";
 import "./index.css";
@@ -14,6 +15,7 @@ initStandaloneListBox();
 initRecordingInputOptions();
 initRegionSelector();
 initRecordingSourceSelector();
+initRecordingDock();
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/stores/recording-state.store.ts
+++ b/src/stores/recording-state.store.ts
@@ -6,7 +6,7 @@ import {
   WindowDetails,
 } from "../features/recording-source/api/recording-sources";
 
-const STORE_NAME = "recordingPreferences";
+const STORE_NAME = "recordingState";
 
 export enum RecordingType {
   Region = "region",
@@ -19,14 +19,16 @@ export type Region = {
   size: { height: number; width: number };
 };
 
-type RecordingPreferencesState = {
+type RecordingStateProps = {
   camera: boolean;
+  isRecording: boolean;
   microphone: boolean;
   recordingType: RecordingType;
   region: Region;
   selectedMonitor: MonitorDetails | null;
   selectedWindow: WindowDetails | null;
   setCamera: (camera: boolean) => void;
+  setIsRecording: (isRecording: boolean) => void;
   setMicrophone: (microphone: boolean) => void;
   setRecordingType: (recordingType: RecordingType) => void;
   setRegion: (region: Region) => void;
@@ -36,11 +38,12 @@ type RecordingPreferencesState = {
   systemAudio: boolean;
 };
 
-export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
+export const useRecordingStateStore = create<RecordingStateProps>()(
   devtools(
     persist(
       (set) => ({
         camera: false,
+        isRecording: false,
         microphone: false,
         recordingType: RecordingType.Region,
         region: {
@@ -51,6 +54,9 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
         selectedWindow: null,
         setCamera: (camera) => {
           set({ camera });
+        },
+        setIsRecording: (isRecording) => {
+          set({ isRecording });
         },
         setMicrophone: (microphone) => {
           set({ microphone });
@@ -77,9 +83,9 @@ export const useRecordingPreferencesStore = create<RecordingPreferencesState>()(
   )
 );
 
-export const rehydrateRecordingPreferencesStore = (e: StorageEvent) => {
+export const rehydrateRecordingStateStore = (e: StorageEvent) => {
   const { key } = e;
   if (key === STORE_NAME) {
-    void useRecordingPreferencesStore.persist.rehydrate();
+    void useRecordingStateStore.persist.rehydrate();
   }
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -30,4 +30,7 @@ export enum Commands {
   StopMagnifierCapture = "stop_magnifier_capture",
   InitMagnifierCapturer = "init_magnifier_capturer",
   ListWindows = "list_windows",
+  InitRecordingDock = "init_recording_dock",
+  StartRecording = "start_recording",
+  StopRecording = "stop_recording",
 }


### PR DESCRIPTION
Abandoned the idea of elapsed time in the system tray icon. Although this is possible in MacOS, it is not in Windows. When windows support is added the experience should be consistent across platforms.

https://github.com/user-attachments/assets/9b89948e-4895-490a-9a96-2eff5edc4787