### PR TITLE
Add `generate_thumbnails` option to list command

### DIFF
--- a/src-tauri/src/recording_sources/commands.rs
+++ b/src-tauri/src/recording_sources/commands.rs
@@ -51,7 +51,15 @@ pub fn list_monitors(app_handle: AppHandle) -> Vec<MonitorDetails> {
 }
 
 #[tauri::command]
-pub async fn list_windows(app_handle: AppHandle) -> Vec<WindowDetails> {
+pub async fn list_windows(app_handle: AppHandle, generate_thumbnails: bool) -> Vec<WindowDetails> {
   let app_temp_dir = app_handle.path().temp_dir().unwrap().join("OrbitCursor");
-  get_visible_windows(app_handle.available_monitors().unwrap(), Some(app_temp_dir)).await
+  get_visible_windows(
+    app_handle.available_monitors().unwrap(),
+    if generate_thumbnails {
+      Some(app_temp_dir)
+    } else {
+      None
+    },
+  )
+  .await
 }

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -75,22 +75,24 @@ const RecordingSourceSelector = () => {
   };
 
   useEffect(() => {
-    void listMonitors().then((monitors) => {
-      if (
-        selectedMonitor === null ||
-        (!monitors.find((monitor) => monitor.id === selectedMonitor.id) &&
-          monitors.length > 0)
-      ) {
-        setSelectedMonitor(monitors[0]);
-      }
-    });
-
-    if (selectedWindow !== null) {
-      void listWindows().then((windows) => {
-        const doesSelectedExist =
-          windows.findIndex((x) => x.id === selectedWindow.id) > -1;
-        if (!doesSelectedExist) setSelectedWindow(null);
+    if (startRecordingDockOpened) {
+      void listMonitors().then((monitors) => {
+        if (
+          selectedMonitor === null ||
+          (!monitors.find((monitor) => monitor.id === selectedMonitor.id) &&
+            monitors.length > 0)
+        ) {
+          setSelectedMonitor(monitors[0]);
+        }
       });
+
+      if (selectedWindow !== null) {
+        void listWindows(isExpanded).then((windows) => {
+          const doesSelectedExist =
+            windows.findIndex((x) => x.id === selectedWindow.id) > -1;
+          if (!doesSelectedExist) setSelectedWindow(null);
+        });
+      }
     }
   }, [startRecordingDockOpened, isExpanded]);
 
@@ -121,6 +123,7 @@ const RecordingSourceSelector = () => {
         (recordingType === RecordingType.Window ? (
           <SelectorWrapper className="overflow-auto items-start">
             <WindowSelector
+              isExpanded={isExpanded}
               onSelect={onSelect}
               selectedWindow={selectedWindow}
             />

--- a/src/features/recording-source/api/recording-sources.ts
+++ b/src/features/recording-source/api/recording-sources.ts
@@ -30,7 +30,7 @@ export const listMonitors = async () => {
   return monitors as MonitorDetails[];
 };
 
-export const listWindows = async () => {
-  const windows = await invoke(Commands.ListWindows);
+export const listWindows = async (generateThumbnails: boolean) => {
+  const windows = await invoke(Commands.ListWindows, { generateThumbnails });
   return windows as WindowDetails[];
 };

--- a/src/features/recording-source/components/window-selector.tsx
+++ b/src/features/recording-source/components/window-selector.tsx
@@ -6,31 +6,38 @@ import Button from "../../../components/button/button";
 import { listWindows, WindowDetails } from "../api/recording-sources";
 
 type WindowSelectorProps = {
+  isExpanded: boolean;
   onSelect: (window: WindowDetails | null) => void;
   selectedWindow: WindowDetails | null;
 };
-const WindowSelector = ({ onSelect, selectedWindow }: WindowSelectorProps) => {
+const WindowSelector = ({
+  isExpanded,
+  onSelect,
+  selectedWindow,
+}: WindowSelectorProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [windows, setWindows] = useState<WindowDetails[]>([]);
 
   useEffect(() => {
-    void listWindows()
-      .then((windows) => {
-        const latestWindows = windows.sort((a, b) => {
-          const appIconCompare = (a.appIconPath ?? "").localeCompare(
-            b.appIconPath ?? ""
-          );
-          if (appIconCompare !== 0) return appIconCompare;
+    if (isExpanded) {
+      void listWindows(isExpanded)
+        .then((windows) => {
+          const latestWindows = windows.sort((a, b) => {
+            const appIconCompare = (a.appIconPath ?? "").localeCompare(
+              b.appIconPath ?? ""
+            );
+            if (appIconCompare !== 0) return appIconCompare;
 
-          return a.title.localeCompare(b.title);
+            return a.title.localeCompare(b.title);
+          });
+
+          setWindows(latestWindows);
+        })
+        .finally(() => {
+          setIsLoading(false);
         });
-
-        setWindows(latestWindows);
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, []);
+    }
+  }, [isExpanded]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Only generate app thumbnails when expanding the windows panel, not on mount - increases UI responsiveness.

I was unable to replicate the UI freeze bug, easily switching between recording type whilst waiting for app thumbnails to load.