### PR TITLE
Add mouse event capture

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -841,22 +841,6 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "cocoa-foundation 0.1.2",
- "core-foundation 0.9.4",
- "core-graphics 0.22.3",
- "foreign-types 0.3.2",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
@@ -1050,19 +1034,6 @@ checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.7.0",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
  "foreign-types 0.3.2",
  "libc",
 ]
@@ -1635,26 +1606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
-name = "enum-map"
-version = "2.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
-dependencies = [
- "enum-map-derive",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,16 +1624,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "epoll"
-version = "4.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
 ]
 
 [[package]]
@@ -2826,26 +2767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,18 +3336,6 @@ checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4169,11 +4078,12 @@ dependencies = [
  "objc",
  "once_cell",
  "rdev",
+ "rmp-serde",
  "scap",
  "serde",
  "serde_json",
- "strum 0.27.1",
- "strum_macros 0.27.1",
+ "strum",
+ "strum_macros",
  "tauri",
  "tauri-build",
  "tauri-nspanel",
@@ -4910,26 +4820,18 @@ dependencies = [
 
 [[package]]
 name = "rdev"
-version = "0.5.0-2"
-source = "git+https://github.com/rustdesk-org/rdev#f9b60b1dd0f3300a1b797d7a74c116683cd232c8"
+version = "0.6.0"
+source = "git+https://github.com/Narsil/rdev?rev=c77b4e5456301cfa7f2226020f2a58f2f8d77c5d#c77b4e5456301cfa7f2226020f2a58f2f8d77c5d"
 dependencies = [
- "cocoa 0.24.1",
- "core-foundation 0.9.4",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys 0.8.7",
- "core-graphics 0.22.3",
+ "core-graphics 0.24.0",
  "dispatch",
- "enum-map",
- "epoll",
- "inotify",
  "lazy_static",
  "libc",
- "log",
- "mio 0.8.11",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "widestring",
+ "serde",
  "winapi",
- "x11",
 ]
 
 [[package]]
@@ -5046,6 +4948,28 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -5628,28 +5552,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum_macros"
@@ -6290,7 +6195,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.3",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ strum = "0.27"
 strum_macros = "0.27"
 tauri-plugin-shell = "2.2.1"
 dispatch = "0.2.0"
-rdev = { git = "https://github.com/rustdesk-org/rdev" }
+rdev = { git = "https://github.com/Narsil/rdev", rev = "c77b4e5456301cfa7f2226020f2a58f2f8d77c5d", features = ["serialize"] }
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }
 tauri-plugin-store = "2"
 cpal = { git = "https://github.com/domingasp/cpal.git"}
@@ -42,6 +42,7 @@ uuid = { version = "1.17.0", features = ["v4"] }
 chrono = "0.4.41"
 hound = "3.5.1"
 ffmpeg-sidecar = "2.0.6"
+rmp-serde = "1.3.0"
 
 [dependencies.nokhwa]
 git = "https://github.com/l1npengtul/nokhwa.git"

--- a/src-tauri/src/global_inputs/service.rs
+++ b/src-tauri/src/global_inputs/service.rs
@@ -1,53 +1,6 @@
-use std::sync::Mutex;
+use rdev::Event;
+use tokio::sync::broadcast;
 
-use once_cell::sync::Lazy;
-use rdev::{Button, Event, EventType};
-use tauri::{Emitter, Manager};
-
-use crate::{
-  constants::{Events, WindowLabel},
-  windows::{commands::collapse_recording_source_selector, service::is_coordinate_in_window},
-  APP_HANDLE,
-};
-
-static LAST_MOUSE_POS: Lazy<Mutex<(f64, f64)>> = Lazy::new(|| Mutex::new((0.0, 0.0)));
-
-pub fn global_input_event_handler(event: Event) {
-  match event.event_type {
-    EventType::MouseMove { x, y } => {
-      let mut pos = LAST_MOUSE_POS.lock().unwrap();
-      *pos = (x, y);
-    }
-    EventType::ButtonRelease(Button::Left) => {
-      let app_handle = APP_HANDLE.get().unwrap();
-
-      // Handle recording input options popover
-      let pos = LAST_MOUSE_POS.lock().unwrap();
-      let recording_input_options_window = app_handle
-        .get_webview_window(WindowLabel::RecordingInputOptions.as_ref())
-        .unwrap();
-
-      let standalone_listbox_window = app_handle
-        .get_webview_window(WindowLabel::StandaloneListbox.as_ref())
-        .unwrap();
-
-      let _ = app_handle.emit(Events::StandaloneListboxDidResignKey.as_ref(), ());
-
-      if !is_coordinate_in_window(pos.0, pos.1, &recording_input_options_window)
-        && !is_coordinate_in_window(pos.0, pos.1, &standalone_listbox_window)
-      {
-        let _ = app_handle.emit(Events::RecordingInputOptionsDidResignKey.as_ref(), ());
-      }
-
-      let recording_source_selector = app_handle
-        .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
-        .unwrap();
-
-      if !is_coordinate_in_window(pos.0, pos.1, &recording_source_selector) {
-        collapse_recording_source_selector(app_handle.clone());
-        let _ = app_handle.emit(Events::CollapsedRecordingSourceSelector.as_ref(), ());
-      }
-    }
-    _ => {}
-  }
+pub fn global_input_event_handler(event: Event, tx: broadcast::Sender<Event>) {
+  let _ = tx.send(event.clone());
 }

--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -4,7 +4,7 @@ use std::{
   sync::{atomic::AtomicBool, Arc},
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumString};
 use tauri::{async_runtime::JoinHandle, LogicalPosition, LogicalSize};
 use tokio::sync::{broadcast::Receiver, Barrier};
@@ -61,4 +61,24 @@ pub enum RecordingFile {
 
   #[strum(serialize = "camera.mp4")]
   Camera,
+
+  #[strum(serialize = "mouse_events.msgpack")]
+  MouseEvents,
+}
+
+#[derive(Debug, Serialize)]
+pub enum MouseEventRecord {
+  Move {
+    elapsed_ms: u128,
+    x: f64,
+    y: f64,
+  },
+  Down {
+    elapsed_ms: u128,
+    button: rdev::Button,
+  },
+  Up {
+    elapsed_ms: u128,
+    button: rdev::Button,
+  },
 }

--- a/src-tauri/src/windows/commands.rs
+++ b/src-tauri/src/windows/commands.rs
@@ -259,23 +259,23 @@ pub fn hide_start_recording_dock(app_handle: AppHandle, state: State<'_, Mutex<A
   state.audio_streams.clear();
 
   let panel = app_handle
-    .get_webview_panel(WindowLabel::StartRecordingDock.as_ref())
+    .get_webview_window(WindowLabel::StartRecordingDock.as_ref())
     .unwrap();
-  panel.order_out(None);
+  let _ = panel.hide();
 
   let recording_source_selector = app_handle
-    .get_webview_panel(WindowLabel::RecordingSourceSelector.as_ref())
+    .get_webview_window(WindowLabel::RecordingSourceSelector.as_ref())
     .unwrap();
-  recording_source_selector.order_out(None);
+  let _ = recording_source_selector.hide();
   collapse_recording_source_selector(app_handle);
 }
 
 #[tauri::command]
 pub fn hide_region_selector(app_handle: AppHandle) {
-  let panel = app_handle
-    .get_webview_panel(WindowLabel::RegionSelector.as_ref())
+  let window = app_handle
+    .get_webview_window(WindowLabel::RegionSelector.as_ref())
     .unwrap();
-  panel.order_out(None);
+  let _ = window.hide();
 }
 
 #[tauri::command]
@@ -334,15 +334,15 @@ pub fn collapse_recording_source_selector(app_handle: AppHandle) {
 pub fn reset_panels(app_handle: AppHandle) {
   collapse_recording_source_selector(app_handle.clone());
 
-  app_handle
-    .get_webview_panel(WindowLabel::RecordingInputOptions.as_ref())
+  let _ = app_handle
+    .get_webview_window(WindowLabel::RecordingInputOptions.as_ref())
     .unwrap()
-    .order_out(None);
+    .hide();
 
-  app_handle
-    .get_webview_panel(WindowLabel::StandaloneListbox.as_ref())
+  let _ = app_handle
+    .get_webview_window(WindowLabel::StandaloneListbox.as_ref())
     .unwrap()
-    .order_out(None);
+    .hide();
 }
 
 #[tauri::command]


### PR DESCRIPTION
`rdev` listener now sends the events via a broadcast channel allowing any function to listen in. For recording the mouse events I've opted to use the MessagePack format, it's more space efficient than something like `csv`.

Window close handling has been moved to its own function, this way input loop is not blocked by this fetching/coordinate calculation.