### PR TITLE
Capture recording metadata into json

### DIFF
--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -53,6 +53,9 @@ pub enum RecordingFile {
 
   #[strum(serialize = "mouse_events.msgpack")]
   MouseEvents,
+
+  #[strum(serialize = "metadata.json")]
+  Metadata,
 }
 
 #[derive(Debug, Serialize)]
@@ -70,4 +73,10 @@ pub enum MouseEventRecord {
     elapsed_ms: u128,
     button: rdev::Button,
   },
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecordingMetadata {
+  pub recording_origin: LogicalPosition<f64>,
+  pub scale_factor: f64,
 }

--- a/src-tauri/src/recording_sources/commands.rs
+++ b/src-tauri/src/recording_sources/commands.rs
@@ -24,6 +24,7 @@ pub struct WindowDetails {
   pub app_icon_path: Option<PathBuf>,
   pub thumbnail_path: Option<PathBuf>,
   pub size: LogicalSize<f64>,
+  pub position: LogicalPosition<f64>,
   pub scale_factor: f64,
 }
 

--- a/src-tauri/src/recording_sources/service.rs
+++ b/src-tauri/src/recording_sources/service.rs
@@ -20,7 +20,7 @@ use objc::{
   sel, sel_impl,
 };
 use scap::{get_all_targets, Target};
-use tauri::{Emitter, LogicalSize, Monitor};
+use tauri::{Emitter, LogicalPosition, LogicalSize, Monitor};
 use uuid::Uuid;
 use xcap::Window;
 
@@ -101,6 +101,7 @@ pub fn get_visible_windows(
           app_icon_path,
           thumbnail_path,
           size: LogicalSize::new(frame.size.width, frame.size.height),
+          position: LogicalPosition::new(frame.origin.x, frame.origin.y),
           scale_factor,
         });
       }

--- a/src/features/recording-source/api/recording-sources.ts
+++ b/src/features/recording-source/api/recording-sources.ts
@@ -19,6 +19,7 @@ export type MonitorDetails = {
 export type WindowDetails = {
   appIconPath: string | null;
   id: number;
+  position: LogicalPosition;
   scaleFactor: number;
   size: LogicalSize;
   thumbnailPath: string | null;


### PR DESCRIPTION
Kept the mouse event log the same, instead capture the recording metadata at the beginning of the recording.

This data can then be used to overlay the mouse with correct position.