### PR TITLE
Fix camera framerate being slower than advertised

### DIFF
--- a/src-tauri/src/camera/service.rs
+++ b/src-tauri/src/camera/service.rs
@@ -54,6 +54,17 @@ pub fn create_camera(
   }
 }
 
+pub fn frame_format_to_ffmpeg(frame_format: FrameFormat) -> &'static str {
+  match frame_format {
+    FrameFormat::MJPEG => "mjpeg",
+    FrameFormat::YUYV => "yuyv422",
+    FrameFormat::NV12 => "nv12",
+    FrameFormat::GRAY => "gray",
+    FrameFormat::RAWRGB => "rgb24",
+    FrameFormat::RAWBGR => "bgr24",
+  }
+}
+
 fn yuyv_to_rgba(buffer: &[u8], width: u32, height: u32) -> Vec<u8> {
   let mut rgba_buffer = vec![0u8; (width * height * 4) as usize];
 


### PR DESCRIPTION
Happened due to converting frames to RGBA before sending via channel. This has now been offloaded to ffmpeg.

Although `ffprobe` reports screen as `25/1` the actual frames and length is correct - this is not a problem.