### PR TITLE
Add logging for start recording

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-query": "^5.74.4",
     "@tauri-apps/api": "^2.5.0",
     "@tauri-apps/plugin-dialog": "~2",
+    "@tauri-apps/plugin-log": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-os": "~2",
     "@tauri-apps/plugin-store": "~2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ~2
         version: 2.3.0
+      '@tauri-apps/plugin-log':
+        specifier: ^2.6.0
+        version: 2.6.0
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.2.6
@@ -1665,6 +1668,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.3.0':
     resolution: {integrity: sha512-ylSBvYYShpGlKKh732ZuaHyJ5Ie1JR71QCXewCtsRLqGdc8Is4xWdz6t43rzXyvkItM9syNPMvFVcvjgEy+/GA==}
+
+  '@tauri-apps/plugin-log@2.6.0':
+    resolution: {integrity: sha512-gVp3l31akA1Jk2bZsTA0hMFD5/gLe49Nw1btu5lViau0QqgC2XyT79LSwvy7a44ewtQbSexchqIg7oTJKMIbXQ==}
 
   '@tauri-apps/plugin-opener@2.2.6':
     resolution: {integrity: sha512-bSdkuP71ZQRepPOn8BOEdBKYJQvl6+jb160QtJX/i2H9BF6ZySY/kYljh76N2Ne5fJMQRge7rlKoStYQY5Jq1w==}
@@ -5679,6 +5685,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.4.1
 
   '@tauri-apps/plugin-dialog@2.3.0':
+    dependencies:
+      '@tauri-apps/api': 2.6.0
+
+  '@tauri-apps/plugin-log@2.6.0':
     dependencies:
       '@tauri-apps/api': 2.6.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -29,6 +29,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +96,23 @@ name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "android_system_properties"
@@ -490,6 +518,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +589,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +643,39 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byte-unit"
+version = "5.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1648,6 +1744,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1828,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1843,6 +1958,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -2417,6 +2538,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3198,6 +3322,9 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loop9"
@@ -3707,6 +3834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4105,6 +4241,7 @@ dependencies = [
  "futures",
  "hound",
  "image",
+ "log",
  "nokhwa",
  "objc",
  "once_cell",
@@ -4119,6 +4256,7 @@ dependencies = [
  "tauri-build",
  "tauri-nspanel",
  "tauri-plugin-dialog",
+ "tauri-plugin-log",
  "tauri-plugin-macos-permissions",
  "tauri-plugin-opener",
  "tauri-plugin-os",
@@ -4615,6 +4753,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4670,6 +4828,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4929,6 +5093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,6 +5194,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5242,22 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5225,6 +5443,12 @@ dependencies = [
  "objc_id",
  "once_cell",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
@@ -5464,6 +5688,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5798,6 +6028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,6 +6236,28 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73d224e9bcb44677d56c422c85a2a345518f1df192acb5f7c1fb5a0c5bc791ee"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2 0.6.1",
+ "objc2-foundation 0.3.1",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
+ "time",
 ]
 
 [[package]]
@@ -6290,7 +6548,9 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa 1.0.15",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -6322,6 +6582,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -6656,6 +6931,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6703,6 +6984,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "version-compare"
@@ -7941,6 +8228,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,8 @@ ffmpeg-sidecar = "2.0.6"
 rmp-serde = "1.3.0"
 tauri-plugin-os = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-log = "2"
+log = "0.4"
 
 [dependencies.nokhwa]
 git = "https://github.com/l1npengtul/nokhwa.git"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
     },
     "store:default",
     "os:default",
-    "dialog:default"
+    "dialog:default",
+    "log:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,6 +185,11 @@ pub fn run() {
     .plugin(tauri_plugin_shell::init())
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_store::Builder::new().build())
+    .plugin(
+      tauri_plugin_log::Builder::new()
+        .level(log::LevelFilter::Info)
+        .build(),
+    )
     .setup(|app: &mut App| {
       let store = tauri::async_runtime::block_on(setup_store(app));
 

--- a/src-tauri/src/recording/service.rs
+++ b/src-tauri/src/recording/service.rs
@@ -248,7 +248,7 @@ pub fn start_camera_recording(
   file_path: PathBuf,
   camera_name: String,
 ) {
-  log::info!("Search for camera: {}", camera_name);
+  log::info!("Search for camera: {camera_name}");
   let available_cameras = nokhwa::query(nokhwa::utils::ApiBackend::Auto).unwrap();
   let camera_info = available_cameras
     .iter()
@@ -545,16 +545,16 @@ fn start_audio_recording(
 ) {
   let file_stem = file_path.file_stem().unwrap().to_string_lossy().to_string();
 
-  log::info!("Building audio stream {}", file_stem);
+  log::info!("Building audio stream {file_stem}");
   let (stream, wav_writer) =
     build_audio_into_file_stream(&device, &config, &file_path, synchronization.start_writing);
   stream.play().expect("Failed to start system audio stream");
-  log::info!("Audio stream {} started", file_stem);
+  log::info!("Audio stream {file_stem} started");
 
   let mut stop_rx = synchronization.stop_tx.subscribe();
   tauri::async_runtime::spawn(async move {
     let _ = stop_rx.recv().await;
-    log::info!("Audio stream {} received stop signal", file_stem);
+    log::info!("Audio stream {file_stem} received stop signal");
 
     drop(stream); // cpal has no stop capability, stream cleaned on drop
 
@@ -563,7 +563,7 @@ fn start_audio_recording(
       writer.finalize().unwrap();
     }
 
-    log::info!("Audio stream {} has shut down", file_stem);
+    log::info!("Audio stream {file_stem} has shut down");
     synchronization.stop_barrier.wait();
   });
 }

--- a/src-tauri/src/recording/service.rs
+++ b/src-tauri/src/recording/service.rs
@@ -179,6 +179,7 @@ fn create_screen_capturer(
   window_id: Option<u32>,
   region: Region,
 ) -> CapturerInfo {
+  log::info!("Fetching display data");
   let monitors = list_monitors(app_handle.clone());
   let monitor = monitors
     .iter()
@@ -196,18 +197,22 @@ fn create_screen_capturer(
   let mut crop_origin: Option<PhysicalPosition<f64>> = None;
 
   let mut recording_origin = monitor.position;
+  log::info!("Monitor details ready");
 
   if let (RecordingType::Window, Some(window_id)) = (recording_type, window_id) {
+    log::info!("Fetching window details");
     let windows = get_visible_windows(app_handle.clone().available_monitors().unwrap(), None);
     let window_details = windows.into_iter().find(|w| w.id == window_id);
 
     // Details are not the same as scap::Target
     if let Some(window_details) = window_details {
+      log::info!("Window details found, fetching window target");
       let window_size = window_details.size.to_physical(window_details.scale_factor);
       let window_target = get_window(window_id);
 
       // Only if we can find the target will we use it, otherwise use default (screen)
       if let Some(window_target) = window_target {
+        log::info!("Window target found, configuring window details");
         target = Some(window_target);
         width = window_size.width;
         height = window_size.height;
@@ -215,6 +220,7 @@ fn create_screen_capturer(
       }
     }
   } else if recording_type == RecordingType::Region {
+    log::info!("Configuring region details");
     crop_size = Some(region.size.to_physical(scale_factor));
     crop_origin = Some(region.position.to_physical(scale_factor));
     recording_origin = region.position;
@@ -222,7 +228,8 @@ fn create_screen_capturer(
 
   // We don't use scap crop area due to strange behaviour with ffmpeg, instead we crop directly
   // in ffmpeg
-  let capturer = create_screen_recording_capturer(app_handle, target);
+  let capturer = create_screen_recording_capturer(target);
+  log::info!("Screen capturer created");
 
   (
     capturer,
@@ -241,12 +248,14 @@ pub fn start_camera_recording(
   file_path: PathBuf,
   camera_name: String,
 ) {
+  log::info!("Search for camera: {}", camera_name);
   let available_cameras = nokhwa::query(nokhwa::utils::ApiBackend::Auto).unwrap();
   let camera_info = available_cameras
     .iter()
     .find(|c| c.human_name() == camera_name)
     .unwrap();
   let camera_index = camera_info.index().clone();
+  log::info!("Camera found");
 
   let start_writing_for_writer = synchronization.start_writing.clone();
 
@@ -292,8 +301,10 @@ fn spawn_camera_with_send(
   start_writing: Arc<AtomicBool>,
   mut stop_rx: broadcast::Receiver<()>,
 ) -> (nokhwa::utils::Resolution, u32, String) {
+  log::info!("Creating camera");
   let mut camera = create_camera(camera_index, move |frame| {
     if let Some(tx) = camera_ready_tx.lock().unwrap().take() {
+      log::info!("Camera started reading frames");
       let _ = tx.send(());
     }
 
@@ -312,11 +323,13 @@ fn spawn_camera_with_send(
   );
 
   std::thread::spawn(move || {
+    log::info!("Opening camera stream");
     if let Err(e) = camera.open_stream() {
       eprintln!("Failed to start camera: {e}");
     }
 
     let _ = stop_rx.blocking_recv(); // Keeps camera alive
+    log::info!("Camera received stop signal")
   });
 
   (resolution, frame_rate, frame_format.to_string())
@@ -331,9 +344,11 @@ fn spawn_ffmpeg_frame_writer(
   stop_barrier: Arc<Barrier>,
 ) {
   std::thread::spawn(move || {
+    log::info!("Starting ffmpeg writer thread");
     let mut stdin = std::io::BufWriter::new(ffmpeg_child.take_stdin().unwrap());
     loop {
       if stop_rx.try_recv().is_ok() {
+        log::info!("Ffmpeg received stop signal");
         break;
       }
 
@@ -352,12 +367,18 @@ fn spawn_ffmpeg_frame_writer(
       }
     }
 
+    log::info!("Flushing ffmpeg");
     if let Err(e) = stdin.flush() {
       eprintln!("Failed to flush ffmpeg stdin: {e}");
     }
 
+    log::info!("Dropping stdin");
     drop(stdin); // signals EOF to ffmpeg
+
+    log::info!("Clearing ffmpeg child process resources");
     let _ = ffmpeg_child.wait();
+
+    log::info!("Ffmpeg writer finished");
     stop_barrier.wait();
   });
 }
@@ -371,6 +392,7 @@ fn spawn_capturer_with_send(
   start_writing: Arc<AtomicBool>,
   mut stop_rx: broadcast::Receiver<()>,
 ) {
+  log::info!("Starting screen capturer");
   capturer.start_capture();
 
   std::thread::spawn(move || {
@@ -380,6 +402,7 @@ fn spawn_capturer_with_send(
 
     loop {
       if stop_rx.try_recv().is_ok() {
+        log::info!("Screen capturer received stop signal");
         break;
       }
 
@@ -443,6 +466,10 @@ fn create_ffmpeg_writer(
   crop_size: Option<PhysicalSize<f64>>,
   crop_origin: Option<PhysicalPosition<f64>>,
 ) -> FfmpegChild {
+  log::info!(
+    "Initializing ffmpeg writer for {}",
+    file_path.file_stem().unwrap().to_string_lossy()
+  );
   let mut child = FfmpegCommand::new();
 
   if let Some(ref frame_rate) = frame_rate {
@@ -516,13 +543,19 @@ fn start_audio_recording(
   device: Device,
   config: StreamConfig,
 ) {
+  let file_stem = file_path.file_stem().unwrap().to_string_lossy().to_string();
+
+  log::info!("Building audio stream {}", file_stem);
   let (stream, wav_writer) =
     build_audio_into_file_stream(&device, &config, &file_path, synchronization.start_writing);
   stream.play().expect("Failed to start system audio stream");
+  log::info!("Audio stream {} started", file_stem);
 
   let mut stop_rx = synchronization.stop_tx.subscribe();
   tauri::async_runtime::spawn(async move {
     let _ = stop_rx.recv().await;
+    log::info!("Audio stream {} received stop signal", file_stem);
+
     drop(stream); // cpal has no stop capability, stream cleaned on drop
 
     let mut writer_lock = wav_writer.lock().unwrap();
@@ -530,6 +563,7 @@ fn start_audio_recording(
       writer.finalize().unwrap();
     }
 
+    log::info!("Audio stream {} has shut down", file_stem);
     synchronization.stop_barrier.wait();
   });
 }

--- a/src-tauri/src/screen_capture/commands.rs
+++ b/src-tauri/src/screen_capture/commands.rs
@@ -4,19 +4,15 @@ use std::{
 };
 
 use scap::frame::Frame;
-use tauri::{ipc::Channel, AppHandle, Manager, State};
+use tauri::{ipc::Channel, Manager, State};
 
 use crate::{AppState, APP_HANDLE};
 
 use super::service::{self, bgra_frame_to_rgba_buffer};
 
 #[tauri::command]
-pub fn init_magnifier_capturer(
-  app_handle: AppHandle,
-  state: State<'_, Mutex<AppState>>,
-  display_name: String,
-) {
-  service::init_magnifier_capturer(app_handle, state, display_name);
+pub fn init_magnifier_capturer(state: State<'_, Mutex<AppState>>, display_name: String) {
+  service::init_magnifier_capturer(state, display_name);
 }
 
 #[tauri::command]


### PR DESCRIPTION
Also fix bug when input recording open and recording is started. App handle was failing to get `webview_windows`, not sure why. Didn't happen with source selector.

Added logging for start recording to easier debug future bugs.

Opted to store window titles in a static `OnceCell` - these should never change.

On Mac log file is stored in `~/Library/Logs/com.orbit-cursor.app`.

---
I investigates recording straight into multiple audio streams on screen recording mp4. Conclusion was that as the editor is web based, `video` tags only support one audio track for playback. Hence the approach of separate tracks works fine, will need to better sync them up.