### PR TITLE
Improve camera preview performance

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4245,6 +4245,7 @@ dependencies = [
  "nokhwa",
  "objc",
  "once_cell",
+ "rayon",
  "rdev",
  "rmp-serde",
  "scap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tauri-plugin-os = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
 log = "0.4"
+rayon = "1.10.0"
 
 [dependencies.nokhwa]
 git = "https://github.com/l1npengtul/nokhwa.git"


### PR DESCRIPTION
Introduced `rayon` to parallelise YUVY frame conversion. Now chunks and converts entire rows of pixel data at a time rather than one by one.

- Before: `50 ~ 60ms`
- After: `5ms`

This should in theory support 60fps cameras which run at around `16ms`.