### PR TITLE
External camera out of sync + screen pause

### DIFF
--- a/src-tauri/src/recording/camera.rs
+++ b/src-tauri/src/recording/camera.rs
@@ -83,8 +83,8 @@ fn spawn_camera_recorder(
       frame_rate,
       pixel_format: camera_frame_format_to_ffmpeg(frame_format).to_string(),
       wallclock_timestamps: false,
+      crop: None,
     },
-    None,
     log_prefix.clone(),
   );
   let writer = Arc::new(Mutex::new(Some(stdin)));

--- a/src-tauri/src/recording/camera.rs
+++ b/src-tauri/src/recording/camera.rs
@@ -21,7 +21,10 @@ use tokio::sync::broadcast;
 
 use crate::{
   camera::service::{create_camera, get_camera_details},
-  recording::{ffmpeg::spawn_rawvideo_ffmpeg, models::StreamSync},
+  recording::{
+    ffmpeg::{spawn_rawvideo_ffmpeg, FfmpegInputDetails},
+    models::StreamSync,
+  },
 };
 
 /// Mapping from nokhwa to Ffmpeg compatible frame formats
@@ -74,10 +77,13 @@ fn spawn_camera_recorder(
   let (resolution, frame_rate, frame_format) = get_camera_details(camera_info.index().clone());
   let (ffmpeg, stdin) = spawn_rawvideo_ffmpeg(
     &file_path,
-    resolution.width(),
-    resolution.height(),
-    frame_rate,
-    camera_frame_format_to_ffmpeg(frame_format).to_string(),
+    FfmpegInputDetails {
+      width: resolution.width(),
+      height: resolution.height(),
+      frame_rate,
+      pixel_format: camera_frame_format_to_ffmpeg(frame_format).to_string(),
+      wallclock_timestamps: false,
+    },
     None,
     log_prefix.clone(),
   );

--- a/src-tauri/src/recording/ffmpeg.rs
+++ b/src-tauri/src/recording/ffmpeg.rs
@@ -1,25 +1,32 @@
 use std::{
+  fs::File,
   io::{BufRead, BufReader},
-  path::Path,
+  path::{Path, PathBuf},
   process::{ChildStderr, ChildStdin},
 };
 
 use ffmpeg_sidecar::{child::FfmpegChild, command::FfmpegCommand};
 use tauri::{PhysicalPosition, PhysicalSize};
+use uuid::Uuid;
 
+use crate::recording::models::RecordingFile;
+
+use std::io::Write;
+
+#[derive(Debug, Clone)]
 pub struct FfmpegInputDetails {
   pub width: u32,
   pub height: u32,
   pub frame_rate: u32,
   pub pixel_format: String,
   pub wallclock_timestamps: bool,
+  pub crop: Option<(PhysicalSize<f64>, PhysicalPosition<f64>)>,
 }
 
 /// Create and spawn the camera writer ffmpeg
 pub fn spawn_rawvideo_ffmpeg(
   file_path: &Path,
   input_details: FfmpegInputDetails,
-  crop: Option<(PhysicalSize<f64>, PhysicalPosition<f64>)>,
   log_prefix: String,
 ) -> (FfmpegChild, ChildStdin) {
   log::info!("{log_prefix} Spawning rawvideo ffmpeg");
@@ -30,6 +37,7 @@ pub fn spawn_rawvideo_ffmpeg(
     frame_rate,
     pixel_format,
     wallclock_timestamps,
+    crop,
   } = input_details;
 
   let mut command = FfmpegCommand::new();
@@ -81,6 +89,53 @@ pub fn spawn_rawvideo_ffmpeg(
     .expect("Failed to take stdin for video Ffmpeg");
 
   (ffmpeg, stdin)
+}
+
+/// Concat provided screen segments into a single file
+///
+/// Deletes segments after operation is complete.
+pub fn concat_screen_segments(screen_segments: Vec<PathBuf>, recording_dir: PathBuf) {
+  log::info!("Generating screen segment list file");
+  let segments_path = recording_dir.join(format!("screen-segments_{}.txt", Uuid::new_v4()));
+  let mut file = File::create(&segments_path).unwrap();
+  for path in &screen_segments {
+    let _ = writeln!(file, "file '{}'", path.display());
+  }
+
+  log::info!("Concating screen recording segments");
+  let mut child = FfmpegCommand::new();
+
+  child.format("concat");
+  child.args(["-safe", "0"]);
+  child.input(segments_path.to_string_lossy());
+  child.args(["-c", "copy"]);
+  child.output(
+    recording_dir
+      .join(RecordingFile::Screen.as_ref())
+      .to_string_lossy(),
+  );
+
+  let mut ffmpeg_child = child.spawn().unwrap();
+  let _ = ffmpeg_child.wait();
+
+  log::info!("Concat complete, cleaning up");
+  for segment in &screen_segments {
+    if let Err(e) = std::fs::remove_file(segment) {
+      log::warn!(
+        "Failed to delete recording segment {}: {}",
+        segment.display(),
+        e
+      );
+    }
+  }
+
+  if let Err(e) = std::fs::remove_file(&segments_path) {
+    log::warn!(
+      "Failed to delete list file {}: {}",
+      segments_path.display(),
+      e
+    );
+  }
 }
 
 #[cfg(debug_assertions)]

--- a/src-tauri/src/recording/screen.rs
+++ b/src-tauri/src/recording/screen.rs
@@ -21,7 +21,7 @@ use tokio::sync::broadcast;
 use crate::{
   recording::{
     ffmpeg::{spawn_rawvideo_ffmpeg, FfmpegInputDetails},
-    models::{RecordingType, Region, StreamSync},
+    models::{RecordingType, Region, ScreenCaptureDetails, StreamSync},
   },
   recording_sources::{commands::list_monitors, service::get_visible_windows},
   screen_capture::service::{get_app_targets, get_display},
@@ -45,7 +45,12 @@ pub fn start_screen_recorder(
   window_id: Option<u32>,
   region: Region,
   synchronization: StreamSync,
-) -> (JoinHandle<()>, LogicalPosition<f64>, f64) {
+) -> (
+  JoinHandle<()>,
+  ScreenCaptureDetails,
+  LogicalPosition<f64>,
+  f64,
+) {
   let log_prefix = "[screen]";
 
   let CapturerInfo {
@@ -57,16 +62,17 @@ pub fn start_screen_recorder(
     scale_factor,
   } = create_screen_recorder(recording_type, monitor_name, window_id, region);
 
+  let ffmpeg_input_details = FfmpegInputDetails {
+    width,
+    height,
+    frame_rate: 60,
+    pixel_format: "nv12".to_string(),
+    wallclock_timestamps: true,
+    crop,
+  };
   let (ffmpeg, stdin) = spawn_rawvideo_ffmpeg(
     &file_path,
-    FfmpegInputDetails {
-      width,
-      height,
-      frame_rate: 60,
-      pixel_format: "nv12".to_string(), // Hardware safe
-      wallclock_timestamps: true,
-    },
-    crop,
+    ffmpeg_input_details.clone(),
     log_prefix.to_string(),
   );
   let writer = Arc::new(Mutex::new(stdin));
@@ -75,20 +81,59 @@ pub fn start_screen_recorder(
   capturer.start_capture();
   build_capturer_stream(
     capturer,
-    writer,
+    writer.clone(),
     synchronization.should_write.clone(),
+    // We keep capturer alive until final stop signal is sent
     synchronization.stop_tx.subscribe(),
     synchronization.ready_barrier,
   );
 
   (
     spawn_screen_thread(
-      synchronization.stop_tx.subscribe(),
+      synchronization.stop_screen_tx.subscribe(),
+      writer.clone(),
       ffmpeg,
       log_prefix.to_string(),
     ),
+    ScreenCaptureDetails {
+      writer: writer.clone(),
+      ffmpeg_input_details,
+      log_prefix: log_prefix.to_string(),
+    },
     recording_origin,
     scale_factor,
+  )
+}
+
+pub fn resume_screen_recording(
+  file_path: PathBuf,
+  screen_capture_details: ScreenCaptureDetails,
+  stop_screen_rx: broadcast::Receiver<()>,
+) -> JoinHandle<()> {
+  let ScreenCaptureDetails {
+    writer,
+    ffmpeg_input_details,
+    log_prefix,
+  } = screen_capture_details;
+
+  let (ffmpeg, stdin) = spawn_rawvideo_ffmpeg(
+    &file_path,
+    ffmpeg_input_details.clone(),
+    log_prefix.to_string(),
+  );
+
+  {
+    let mut writer_guard = writer.lock();
+
+    // Swap in new stdin into writer
+    let _ = std::mem::replace(&mut *writer_guard, stdin);
+  }
+
+  spawn_screen_thread(
+    stop_screen_rx,
+    writer.clone(),
+    ffmpeg,
+    log_prefix.to_string(),
   )
 }
 
@@ -251,6 +296,7 @@ fn build_capturer_stream(
 /// Spawn screen thread for starting/tearing down and finalizing recording
 fn spawn_screen_thread(
   mut stop_rx: broadcast::Receiver<()>,
+  writer: Arc<Mutex<ChildStdin>>,
   mut ffmpeg: FfmpegChild,
   log_prefix: String,
 ) -> JoinHandle<()> {
@@ -258,10 +304,26 @@ fn spawn_screen_thread(
     let _ = stop_rx.blocking_recv();
 
     log::info!("{log_prefix} Cleaning up screen ffmpeg");
+    {
+      let mut writer_guard = writer.lock();
+
+      // Take ownership and swap with dummy - needed to signal EOF to ffmpeg
+      let _ = std::mem::replace(&mut *writer_guard, closed_child_stdin());
+    }
     let _ = ffmpeg.wait();
 
     log::info!("{log_prefix} Screen ffmpeg finished");
   })
+}
+
+/// Returns a dummy stdin allow swapping out where required
+fn closed_child_stdin() -> ChildStdin {
+  std::process::Command::new("true")
+    .stdin(std::process::Stdio::piped())
+    .spawn()
+    .expect("Failed to spawn dummy process")
+    .stdin
+    .expect("Failed to get dummy stdin")
 }
 
 /// Return window from id (scap::Target id)


### PR DESCRIPTION
For screen recording instead of constant framerate I've moved to `use_wallclock_as_timestamps` this ensures any frame drops don't cause out of sync issues. This was happening when external camera was plugged in.

For pausing the screen recording 2 approaches are used:
- `camera`, `system_audio` and `microphone` - enough for `should_write` to be false. Ffmpeg does try to fill in the missing gaps as there are not timestamps associated with the data,
- `screen` - separate files are generated at every pause and concated together at the end. This operation doesn't involve a re-encode and is almost instantaneous. This approach is preferred due to the frames being given timestamps by the new flag, ffmpeg then adds freeze frames in the times where there is no new frames being sent and interpolates the difference.