### PR TITLE
Move camera streams to use wallclock timestamps

### DIFF
--- a/src-tauri/src/camera/service.rs
+++ b/src-tauri/src/camera/service.rs
@@ -43,15 +43,14 @@ pub fn live_frame_callback(frame: Buffer, channel: &Channel) {
   let _ = channel.send(tauri::ipc::InvokeResponseBody::Raw(combined));
 }
 
-pub fn get_camera_details(camera_index: CameraIndex) -> (Resolution, u32, FrameFormat) {
+pub fn get_camera_details(camera_index: CameraIndex) -> (Resolution, FrameFormat) {
   let requested = RequestedFormat::new::<RgbAFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
   let camera = Camera::new(camera_index, requested).unwrap();
 
   let resolution = camera.resolution();
-  let frame_rate = camera.frame_rate();
   let frame_format = camera.frame_format();
 
-  (resolution, frame_rate, frame_format)
+  (resolution, frame_format)
 }
 
 pub fn create_camera(

--- a/src-tauri/src/recording/mod.rs
+++ b/src-tauri/src/recording/mod.rs
@@ -6,3 +6,4 @@ mod file;
 mod input_events;
 pub mod models;
 mod screen;
+mod video;

--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -16,8 +16,8 @@ use crate::recording::ffmpeg::FfmpegInputDetails;
 #[derive(Debug, Clone)]
 pub struct StreamSync {
   pub should_write: Arc<AtomicBool>,
-  // Separate as we stop screen recording anytime we pause/resume
-  pub stop_screen_tx: broadcast::Sender<()>,
+  // Separate as we stop screen/camera recording anytime we pause/resume
+  pub stop_video_tx: broadcast::Sender<()>,
   pub stop_tx: broadcast::Sender<()>,
   pub ready_barrier: Arc<Barrier>,
 }
@@ -119,8 +119,8 @@ impl Default for RecordingFileSet {
 }
 
 #[derive(Debug, Clone)]
-pub struct ScreenCaptureDetails {
-  pub writer: Arc<Mutex<ChildStdin>>,
+pub struct VideoCaptureDetails {
+  pub writer: Arc<Mutex<Option<ChildStdin>>>,
   pub ffmpeg_input_details: FfmpegInputDetails,
   pub log_prefix: String,
 }

--- a/src-tauri/src/recording/video.rs
+++ b/src-tauri/src/recording/video.rs
@@ -1,0 +1,69 @@
+use std::{
+  path::{Path, PathBuf},
+  process::ChildStdin,
+  sync::Arc,
+  thread::JoinHandle,
+};
+
+use ffmpeg_sidecar::child::FfmpegChild;
+use parking_lot::Mutex;
+use tokio::sync::broadcast;
+
+use crate::recording::{
+  ffmpeg::{spawn_rawvideo_ffmpeg, FfmpegInputDetails},
+  models::VideoCaptureDetails,
+};
+
+/// Spawns a thread to handle cleanup of the video stream on stop
+pub fn spawn_video_cleanup_thread(
+  mut stop_rx: broadcast::Receiver<()>,
+  writer: Arc<Mutex<Option<ChildStdin>>>,
+  mut ffmpeg: FfmpegChild,
+  log_prefix: String,
+) -> JoinHandle<()> {
+  std::thread::spawn(move || {
+    let _ = stop_rx.blocking_recv();
+
+    log::info!("{log_prefix} Finalizing video stream");
+    {
+      let mut writer = writer.lock();
+      let _ = writer.take(); // close stdin to ffmpeg
+    }
+
+    let _ = ffmpeg.wait();
+    log::info!("{log_prefix} Video stream finalized");
+  })
+}
+
+/// Resumes a paused video recording
+pub fn resume_video_recording(
+  file_path: PathBuf,
+  capture_details: VideoCaptureDetails,
+  stop_video_rx: broadcast::Receiver<()>,
+) -> JoinHandle<()> {
+  let VideoCaptureDetails {
+    writer,
+    ffmpeg_input_details,
+    log_prefix,
+  } = capture_details;
+
+  let (ffmpeg, stdin) = spawn_rawvideo_ffmpeg(&file_path, ffmpeg_input_details, log_prefix.clone());
+
+  {
+    // Swap in new stdin into writer
+    let mut writer = writer.lock();
+    let _ = (*writer).replace(stdin);
+  }
+
+  spawn_video_cleanup_thread(stop_video_rx, writer, ffmpeg, log_prefix)
+}
+
+/// Spawn ffmpeg process and return stdin + child
+pub fn create_ffmpeg_writer(
+  file_path: &Path,
+  ffmpeg_input_details: FfmpegInputDetails,
+  log_prefix: String,
+) -> (Arc<Mutex<Option<ChildStdin>>>, FfmpegChild) {
+  let (ffmpeg, stdin) = spawn_rawvideo_ffmpeg(file_path, ffmpeg_input_details, log_prefix);
+  (Arc::new(Mutex::new(Some(stdin))), ffmpeg)
+}

--- a/src/app/pages/recording-source-selector.tsx
+++ b/src/app/pages/recording-source-selector.tsx
@@ -97,11 +97,12 @@ export const RecordingSourceSelector = () => {
     const unlisten = listen(Events.WindowThumbnailsGenerated, (result) => {
       // Fetching here due to conditional rendering, we need to verify
       // window still exists on reloading
-      setWindows(result.payload as WindowDetails[]);
+      const windowResults = result.payload as WindowDetails[];
+      setWindows(windowResults);
 
       if (selectedWindow) {
         const doesSelectedExist =
-          windows.findIndex((x) => x.id === selectedWindow.id) > -1;
+          windowResults.findIndex((x) => x.id === selectedWindow.id) > -1;
         if (!doesSelectedExist) setSelectedWindow(null);
       }
     });

--- a/src/features/recording-source/components/recording-source.tsx
+++ b/src/features/recording-source/components/recording-source.tsx
@@ -35,9 +35,9 @@ export const RecordingSource = ({ onPress }: RecordingSourceProps) => {
   );
 
   return (
-    <div className="w-full max-w-[284px] min-h-[26px] flex flex-row gap-2 items-center justify-center overflow-hidden">
+    <div className="w-full max-w-[284px] min-h-[24px] flex flex-row gap-2 items-center justify-center overflow-hidden">
       <ContentRotate
-        className=" flex gap-2 items-center text-xxs justify-center text-muted font-semibold"
+        className="flex gap-2 items-center text-xxs justify-center text-muted font-semibold"
         containerClassName="min-w-16"
         contentKey={
           recordingType === RecordingType.Window ? "window" : "monitor"
@@ -62,7 +62,7 @@ export const RecordingSource = ({ onPress }: RecordingSourceProps) => {
         layout
       >
         <motion.div
-          className="flex-1 min-w-0"
+          className="flex flex-1 min-w-0"
           transition={{ duration: 0.2, ease: "linear" }}
           layout
         >


### PR DESCRIPTION
It seems not all camera drivers provide a frame rate, meaning a default value of 1. This results in incorrect camera recording.

This PR generalises the video track recording and pausing introducing a new `video.rs` module.