### PR TITLE
Add overlayscrollbars

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import "overlayscrollbars/styles/overlayscrollbars.css";
 import "../src/index.css";
 import "./styles.css";
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "dequal": "^2.0.3",
     "lucide-react": "^0.488.0",
     "motion": "^12.23.6",
+    "overlayscrollbars": "^2.11.5",
+    "overlayscrollbars-react": "^0.5.6",
     "react": "^19.1.0",
     "react-aria": "^3.39.0",
     "react-aria-components": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       motion:
         specifier: ^12.23.6
         version: 12.23.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      overlayscrollbars:
+        specifier: ^2.11.5
+        version: 2.11.5
+      overlayscrollbars-react:
+        specifier: ^0.5.6
+        version: 0.5.6(overlayscrollbars@2.11.5)(react@19.1.0)
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3062,6 +3068,15 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  overlayscrollbars-react@0.5.6:
+    resolution: {integrity: sha512-E5To04bL5brn9GVCZ36SnfGanxa2I2MDkWoa4Cjo5wol7l+diAgi4DBc983V7l2nOk/OLJ6Feg4kySspQEGDBw==}
+    peerDependencies:
+      overlayscrollbars: ^2.0.0
+      react: '>=16.8.0'
+
+  overlayscrollbars@2.11.5:
+    resolution: {integrity: sha512-vTUfCtjJbTjiarrxl9qdK04ZxlQdB4ugXfiqctVZytYDXH259OM4whROMGDE6T8uCYmSYPqiOFIKZ1erVkJnFg==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -7254,6 +7269,13 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  overlayscrollbars-react@0.5.6(overlayscrollbars@2.11.5)(react@19.1.0):
+    dependencies:
+      overlayscrollbars: 2.11.5
+      react: 19.1.0
+
+  overlayscrollbars@2.11.5: {}
 
   own-keys@1.0.1:
     dependencies:

--- a/src/features/recording-source/components/selector-wrapper.tsx
+++ b/src/features/recording-source/components/selector-wrapper.tsx
@@ -1,3 +1,5 @@
+import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
+
 import { cn } from "../../../lib/styling";
 
 type SelectorWrapperProps = {
@@ -10,13 +12,19 @@ export const SelectorWrapper = ({
   className,
 }: SelectorWrapperProps) => {
   return (
-    <div
+    <OverlayScrollbarsComponent
       className={cn(
-        "flex justify-center items-center w-full h-full inset-shadow-full rounded-md relative overflow-hidden",
+        "w-full h-full inset-shadow-full rounded-md relative overflow-hidden",
         className
       )}
+      options={{
+        scrollbars: { autoHide: "scroll", theme: "os-theme-orbit-cursor" },
+      }}
+      defer
     >
-      {children}
-    </div>
+      <div className="flex items-center-safe justify-center-safe w-full h-full">
+        {children}
+      </div>
+    </OverlayScrollbarsComponent>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -97,3 +97,15 @@ html,
 body {
   overscroll-behavior: none;
 }
+
+.os-theme-orbit-cursor {
+  --os-size: 10px;
+  --os-padding-perpendicular: 2px;
+  --os-padding-axis: 2px;
+  --os-track-border-radius: 10px;
+  --os-handle-interactive-area-offset: 4px;
+  --os-handle-border-radius: 10px;
+  --os-handle-bg: var(--color-muted);
+  --os-handle-bg-hover: var(--color-content-fg);
+  --os-handle-bg-active: var(--color-content-fg);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import {
   initStandaloneListBox,
 } from "./api/windows";
 import { App } from "./app";
+import "overlayscrollbars/styles/overlayscrollbars.css";
 import "./index.css";
 
 // Ensures backend is ready


### PR DESCRIPTION
Fix different scrollbars across MacOS and Windows. Webviews render native scrollbars, `overlayscrollbars` library hides these and implements a unified appearance.