### PR TITLE
Ability to show system cursor in recording

### DIFF
--- a/src-tauri/src/recording/commands.rs
+++ b/src-tauri/src/recording/commands.rs
@@ -42,6 +42,7 @@ pub struct StartRecordingOptions {
   pub monitor_name: String,
   pub window_id: Option<u32>,
   pub region: Region,
+  pub show_system_cursor: bool,
 }
 
 #[tauri::command]
@@ -137,6 +138,7 @@ pub fn start_recording(app_handle: AppHandle, options: StartRecordingOptions) ->
         options.monitor_name,
         options.window_id,
         options.region,
+        options.show_system_cursor,
         synchronization.clone(),
       );
     log::info!("Screen recorder ready");

--- a/src-tauri/src/recording/screen.rs
+++ b/src-tauri/src/recording/screen.rs
@@ -41,6 +41,7 @@ pub fn start_screen_recorder(
   monitor_name: String,
   window_id: Option<u32>,
   region: Region,
+  show_system_cursor: bool,
   synchronization: StreamSync,
 ) -> (
   JoinHandle<()>,
@@ -58,7 +59,13 @@ pub fn start_screen_recorder(
     recording_origin,
     scale_factor,
     output_size,
-  } = create_screen_recorder(recording_type, monitor_name, window_id, region);
+  } = create_screen_recorder(
+    recording_type,
+    monitor_name,
+    window_id,
+    region,
+    show_system_cursor,
+  );
 
   let ffmpeg_input_details = FfmpegInputDetails {
     width,
@@ -111,6 +118,7 @@ fn create_screen_recorder(
   monitor_name: String,
   window_id: Option<u32>,
   region: Region,
+  show_system_cursor: bool,
 ) -> CapturerInfo {
   let (monitor_position, monitor_size, scale_factor) = get_monitor_details(&monitor_name);
 
@@ -162,7 +170,7 @@ fn create_screen_recorder(
   }
 
   CapturerInfo {
-    capturer: create_scap_capturer(target),
+    capturer: create_scap_capturer(target, show_system_cursor),
     width: width as u32,
     height: height as u32,
     crop,
@@ -264,12 +272,12 @@ fn get_window(window_id: u32) -> Option<Target> {
   })
 }
 
-fn create_scap_capturer(target: Option<Target>) -> Capturer {
+fn create_scap_capturer(target: Option<Target>, show_system_cursor: bool) -> Capturer {
   let targets_to_exclude = get_app_targets();
   let options = Options {
     fps: 60,
     target,
-    show_cursor: false,
+    show_cursor: show_system_cursor,
     show_highlight: false,
     excluded_targets: Some(targets_to_exclude),
     output_type: if cfg!(target_os = "macos") {

--- a/src/components/icons/mouse-pointer-2-off.tsx
+++ b/src/components/icons/mouse-pointer-2-off.tsx
@@ -1,0 +1,24 @@
+import { createLucideIcon } from "lucide-react";
+export const MousePointer2Off = createLucideIcon("mouse-pointer-2-off", [
+  [
+    "path",
+    {
+      d: "m13 7.5 7.688 3.037a.5.5 0 0 1-.063.947L17.5 12",
+      key: "9jyv6n",
+    },
+  ],
+  [
+    "path",
+    {
+      d: "m13.063 14.499-1.579 6.126a.5.5 0 0 1-.947.063l-6.5-16",
+      key: "1kxg81",
+    },
+  ],
+  [
+    "path",
+    {
+      d: "m2 2 18 18",
+      key: "1jqc6n",
+    },
+  ],
+]);

--- a/src/components/select/components/clear-button.tsx
+++ b/src/components/select/components/clear-button.tsx
@@ -52,7 +52,7 @@ export const ClearButton = ({
           if (onClear) onClear();
         }}
       >
-        <X size={size} />
+        <X className="translate-x-0" size={size} />
       </MotionAriaButton>
     </div>
   );

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -133,7 +133,7 @@ export const Toast = ({
         slot="close"
         variant="ghost"
       >
-        <X size={16} />
+        <X className="translate-x-0" size={16} />
       </Button>
     </div>
   );

--- a/src/features/recording-controls/api/recording-state.ts
+++ b/src/features/recording-controls/api/recording-state.ts
@@ -10,6 +10,7 @@ type StartRecordingProps = {
   monitorName: string;
   recordingType: RecordingType;
   region: { position: LogicalPosition; size: LogicalSize };
+  showSystemCursor: boolean;
   systemAudio: boolean;
   windowId: number | undefined;
 };

--- a/src/features/recording-controls/components/input-toggle-groups.tsx
+++ b/src/features/recording-controls/components/input-toggle-groups.tsx
@@ -3,12 +3,15 @@ import {
   CameraOff,
   Mic,
   MicOff,
+  MousePointer2,
   Volume2,
   VolumeOff,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
+import { ToggleButton } from "../../../components/button/toggle-button";
+import { MousePointer2Off } from "../../../components/icons/mouse-pointer-2-off";
 import { usePermissionsStore } from "../../../stores/permissions.store";
 import { useRecordingStateStore } from "../../../stores/recording-state.store";
 import {
@@ -74,6 +77,8 @@ export const InputToggleGroup = ({
     setSystemAudio,
     setCameraHasWarning,
     setMicrophoneHasWarning,
+    showSystemCursor,
+    setShowSystemCursor,
   ] = useRecordingStateStore(
     useShallow((state) => [
       state.camera,
@@ -84,6 +89,8 @@ export const InputToggleGroup = ({
       state.setSystemAudio,
       state.setCameraHasWarning,
       state.setMicrophoneHasWarning,
+      state.showSystemCursor,
+      state.setShowSystemCursor,
     ])
   );
 
@@ -165,6 +172,16 @@ export const InputToggleGroup = ({
             : WarningType.NoPermission
         }
       />
+
+      <ToggleButton
+        isSelected={showSystemCursor}
+        off={<MousePointer2Off size={16} />}
+        onChange={setShowSystemCursor}
+        size="sm"
+        variant="ghost"
+      >
+        <MousePointer2 size={16} />
+      </ToggleButton>
     </div>
   );
 };

--- a/src/features/recording-controls/components/recording-controls.tsx
+++ b/src/features/recording-controls/components/recording-controls.tsx
@@ -65,6 +65,7 @@ export const RecordingControls = () => {
     camera,
     microphoneHasWarning,
     cameraHasWarning,
+    showSystemCursor,
   ] = useRecordingStateStore(
     useShallow((state) => [
       state.recordingType,
@@ -76,6 +77,7 @@ export const RecordingControls = () => {
       state.camera,
       state.microphoneHasWarning,
       state.cameraHasWarning,
+      state.showSystemCursor,
     ])
   );
 
@@ -136,6 +138,7 @@ export const RecordingControls = () => {
         position: new LogicalPosition({ ...region.position }),
         size: new LogicalSize({ ...region.size }),
       },
+      showSystemCursor,
       systemAudio,
       windowId: selectedWindow?.id,
     });

--- a/src/stores/recording-state.store.ts
+++ b/src/stores/recording-state.store.ts
@@ -40,7 +40,9 @@ type RecordingState = {
   setRegion: (region: Region) => void;
   setSelectedMonitor: (selectedMonitor: MonitorDetails) => void;
   setSelectedWindow: (selectedWindow: WindowDetails | null) => void;
+  setShowSystemCursor: (showSystemCursor: boolean) => void;
   setSystemAudio: (systemAudio: boolean) => void;
+  showSystemCursor: boolean;
   systemAudio: boolean;
 };
 
@@ -91,9 +93,13 @@ export const useRecordingStateStore = create<RecordingState>()(
         setSelectedWindow: (selectedWindow) => {
           set({ selectedWindow });
         },
+        setShowSystemCursor: (showSystemCursor) => {
+          set({ showSystemCursor });
+        },
         setSystemAudio: (systemAudio) => {
           set({ systemAudio });
         },
+        showSystemCursor: false,
         systemAudio: false,
       }),
       { name: STORE_NAME }


### PR DESCRIPTION
A future item is raw exporting, meaning as is. In this case the user may want to see the cursor in the screen recording. Had to create a custom icon for cursor off - a PR has been raised, until then, I've created a new custom Lucide Icon.

## Off
<img width="546" height="138" alt="image" src="https://github.com/user-attachments/assets/9bdf8423-fef3-41e5-85c5-868e1c3867e5" />


## On
<img width="546" height="138" alt="image" src="https://github.com/user-attachments/assets/936a06b8-cbb9-46f1-96b5-85e09ffbf860" />
